### PR TITLE
Add support for PHP Namespaces

### DIFF
--- a/lib/class-function-call-reflector.php
+++ b/lib/class-function-call-reflector.php
@@ -25,6 +25,10 @@ class Function_Call_Reflector extends BaseReflector {
 
 		$shortName = $this->getShortName();
 
+		if ( is_a( $shortName, 'PHPParser_Node_Name_FullyQualified' ) ) {
+			return '\\' . (string) $shortName;
+		}
+
 		if ( is_a( $shortName, 'PHPParser_Node_Name' ) ) {
 			return (string) $shortName;
 		}

--- a/lib/class-importer.php
+++ b/lib/class-importer.php
@@ -779,7 +779,8 @@ class Importer implements LoggerAwareInterface {
 	 * This creates terms for each of the namespace terms in a hierachical tree
 	 * and then adds the item being processed to each of the terms in that tree.
 	 *
-	 * @param int $post_id The ID of the post item being processed.
+	 * @param int   $post_id    The ID of the post item being processed.
+	 * @param array $namespaces An array of namespaces strings
 	 */
 	protected function _set_namespaces( $post_id, $namespaces ) {
 		$ns_term = false;

--- a/lib/class-method-call-reflector.php
+++ b/lib/class-method-call-reflector.php
@@ -35,6 +35,8 @@ class Method_Call_Reflector extends BaseReflector {
 		if ( $caller instanceof \PHPParser_Node_Expr ) {
 			$printer = new Pretty_Printer;
 			$caller = $printer->prettyPrintExpr( $caller );
+		} elseif ( $caller instanceof \PHPParser_Node_Name_FullyQualified ) {
+			$caller = '\\' . $caller->toString();
 		} elseif ( $caller instanceof \PHPParser_Node_Name ) {
 			$caller = $caller->toString();
 		}
@@ -46,7 +48,7 @@ class Method_Call_Reflector extends BaseReflector {
 
 			// Add parentheses to signify this is a function call
 			/** @var \PHPParser_Node_Expr_FuncCall $caller */
-			$caller = $caller->name->parts[0] . '()';
+			$caller = implode( '\\', $caller->name->parts ) . '()';
 		}
 
 		$class_mapping = $this->_getClassMapping();
@@ -138,14 +140,16 @@ class Method_Call_Reflector extends BaseReflector {
 			return $class;
 		}
 
+
 		switch ( $class ) {
 			case '$this':
 			case 'self':
-				$class = $this->called_in_class->getShortName();
+				$namespace = (string) $this->called_in_class->getNamespace();
+				$namespace = ( 'global' !== $namespace ) ? $namespace . '\\' : '';
+				$class = '\\' . $namespace . $this->called_in_class->getShortName();
 				break;
-
 			case 'parent':
-				$class = $this->called_in_class->getNode()->extends->toString();
+				$class = '\\' . $this->called_in_class->getNode()->extends->toString();
 				break;
 		}
 

--- a/lib/class-plugin.php
+++ b/lib/class-plugin.php
@@ -171,6 +171,22 @@ class Plugin {
 				)
 			);
 		}
+
+		if ( ! taxonomy_exists( 'wp-parser-namespace' ) ) {
+
+			register_taxonomy(
+				'wp-parser-namespace',
+				$object_types,
+				array(
+					'hierarchical'          => true,
+					'label'                 => __( 'Namespaces', 'wp-parser' ),
+					'public'                => true,
+					'rewrite'               => array( 'slug' => 'namespace' ),
+					'sort'                  => false,
+					'update_count_callback' => '_update_post_term_count',
+				)
+			);
+		}
 	}
 
 	/**

--- a/lib/class-relationships.php
+++ b/lib/class-relationships.php
@@ -342,6 +342,29 @@ class Relationships {
 
 	}
 
+	/**
+	 * Map a name to slug, taking into account namespace context.
+	 *
+	 * When a function is called within a namespace, the function is first looked
+	 * for in the current namespace. If it exists, the namespaced version is used.
+	 * If the function does not exist in the current namespace, PHP tries to find
+	 * the function in the global scope.
+	 *
+	 * Unless the call has been prefixed with '\' indicating it is fully qualified
+	 * we need to check first in the current namespace and then in the global
+	 * scope.
+	 *
+	 * This also catches the case where relative namespaces are used. You can
+	 * create a file in namespace `\Foo` and then call a funtion called `baz` in
+	 * namespace `\Foo\Bar\` by just calling `Bar\baz()`. PHP will first look
+	 * for `\Foo\Bar\baz()` and if it can't find it fall back to `\Bar\baz()`.
+	 *
+	 * @see    WP_Parser\Importer::import_item()
+	 * @param  string $name      The name of the item a slug is needed for.
+	 * @param  string $namespace The namespace the item is in when for context.
+	 * @return array             An array of slugs, starting with the context of the
+	 *                           namespace, and falling back to the global namespace.
+	 */
 	public function names_to_slugs( $name, $namespace = null ) {
 		$fully_qualified = ( 0 === strpos( '\\', $name ) );
 		$name = ltrim( $name, '\\' );
@@ -356,17 +379,12 @@ class Relationships {
 	}
 
 	/**
-	 * Convert a method, function, or hook name to a post slug.
+	 * Simple conversion of a method, function, or hook name to a post slug.
 	 *
-	 * Based on context, we may need to check on two names for a fuction because
-	 * if the function call looks to be to global scope, but is from a namespace
-	 * then the call may actually be to a function in that namespace. Similarly,
-	 * PHP will traverse up namespace trees from the current namespace, so we'll
-	 * try to catch that use case as well.
+	 * Replaces '::' and '\' to dashes and then runs the name through `sanitize_title()`.
 	 *
-	 * @see    WP_Parser\Importer::import_item()
 	 * @param  string $name Method, function, or hook name
-	 * @return string       Post slug
+	 * @return string       The post slug for the passed name.
 	 */
 	public function name_to_slug( $name ) {
 		return sanitize_title( str_replace( '\\', '-', str_replace( '::', '-', $name ) ) );

--- a/lib/class-static-method-call-reflector.php
+++ b/lib/class-static-method-call-reflector.php
@@ -13,8 +13,9 @@ class Static_Method_Call_Reflector extends Method_Call_Reflector {
 	 * @return string[] Index 0 is the class name, 1 is the method name.
 	 */
 	public function getName() {
-		$class = $this->node->class->parts[0];
-		$class = $this->_resolveName( $class );
+		$class = $this->node->class;
+		$prefix = ( is_a( $class, 'PHPParser_Node_Name_FullyQualified' ) ) ? '\\' : '';
+		$class = $prefix . $this->_resolveName( implode( '\\', $class->parts ) );
 
 		return array( $class, $this->getShortName() );
 	}

--- a/lib/runner.php
+++ b/lib/runner.php
@@ -89,6 +89,8 @@ function parse_files( $files, $root ) {
 		foreach ( $file->getFunctions() as $function ) {
 			$func = array(
 				'name'      => $function->getShortName(),
+				'namespace' => $function->getNamespace(),
+				'aliases'   => $function->getNamespaceAliases(),
 				'line'      => $function->getLineNumber(),
 				'end_line'  => $function->getNode()->getAttribute( 'endLine' ),
 				'arguments' => export_arguments( $function->getArguments() ),
@@ -110,6 +112,7 @@ function parse_files( $files, $root ) {
 		foreach ( $file->getClasses() as $class ) {
 			$class_data = array(
 				'name'       => $class->getShortName(),
+				'namespace' => $function->getNamespace(),
 				'line'       => $class->getLineNumber(),
 				'end_line'   => $class->getNode()->getAttribute( 'endLine' ),
 				'final'      => $class->isFinal(),
@@ -259,8 +262,11 @@ function export_methods( array $methods ) {
 	$output = array();
 
 	foreach ( $methods as $method ) {
+
 		$method_data = array(
 			'name'       => $method->getShortName(),
+			'namespace'  => $method->getNamespace(),
+			'aliases'    => $method->getNamespaceAliases(),
 			'line'       => $method->getLineNumber(),
 			'end_line'   => $method->getNode()->getAttribute( 'endLine' ),
 			'final'      => $method->isFinal(),

--- a/tests/phpunit/tests/export/uses/constructor.php
+++ b/tests/phpunit/tests/export/uses/constructor.php
@@ -21,7 +21,7 @@ class Export_Constructor_Use extends Export_UnitTestCase {
 				'name'     => '__construct',
 				'line'     => 3,
 				'end_line' => 3,
-				'class'    => 'WP_Query',
+				'class'    => '\WP_Query',
 				'static'   => false,
 			)
 		);
@@ -32,7 +32,7 @@ class Export_Constructor_Use extends Export_UnitTestCase {
 				'name'     => '__construct',
 				'line'     => 6,
 				'end_line' => 6,
-				'class'    => 'My_Class',
+				'class'    => '\My_Class',
 				'static'   => false,
 			)
 		);
@@ -50,7 +50,7 @@ class Export_Constructor_Use extends Export_UnitTestCase {
 				'name'     => '__construct',
 				'line'     => 12,
 				'end_line' => 12,
-				'class'    => 'My_Class',
+				'class'    => '\My_Class',
 				'static'   => false,
 			)
 		);
@@ -68,7 +68,7 @@ class Export_Constructor_Use extends Export_UnitTestCase {
 				'name'     => '__construct',
 				'line'     => 16,
 				'end_line' => 16,
-				'class'    => 'Parent_Class',
+				'class'    => '\Parent_Class',
 				'static'   => false,
 			)
 		);

--- a/tests/phpunit/tests/export/uses/methods.php
+++ b/tests/phpunit/tests/export/uses/methods.php
@@ -21,7 +21,7 @@ class Export_Method_Use extends Export_UnitTestCase {
 				'name'     => 'static_method',
 				'line'     => 3,
 				'end_line' => 3,
-				'class'    => 'My_Class',
+				'class'    => '\My_Class',
 				'static'   => true,
 			)
 		);
@@ -32,7 +32,7 @@ class Export_Method_Use extends Export_UnitTestCase {
 				'name'     => 'another_method',
 				'line'     => 8,
 				'end_line' => 8,
-				'class'    => 'Another_Class',
+				'class'    => '\Another_Class',
 				'static'   => true,
 			)
 		);
@@ -44,7 +44,7 @@ class Export_Method_Use extends Export_UnitTestCase {
 				'name'     => 'do_static_stuff',
 				'line'     => 16,
 				'end_line' => 16,
-				'class'    => 'Another_Class',
+				'class'    => '\Another_Class',
 				'static'   => true,
 			)
 		);
@@ -56,7 +56,7 @@ class Export_Method_Use extends Export_UnitTestCase {
 				'name'     => 'do_stuff',
 				'line'     => 17,
 				'end_line' => 17,
-				'class'    => 'My_Class',
+				'class'    => '\My_Class',
 				'static'   => true,
 			)
 		);
@@ -68,7 +68,7 @@ class Export_Method_Use extends Export_UnitTestCase {
 				'name'     => 'do_parental_stuff',
 				'line'     => 19,
 				'end_line' => 19,
-				'class'    => 'Parent_Class',
+				'class'    => '\Parent_Class',
 				'static'   => true,
 			)
 		);
@@ -107,7 +107,7 @@ class Export_Method_Use extends Export_UnitTestCase {
 				'name'     => 'go',
 				'line'     => 18,
 				'end_line' => 18,
-				'class'    => 'My_Class',
+				'class'    => '\My_Class',
 				'static'   => false,
 			)
 		);

--- a/tests/phpunit/tests/export/uses/nested.php
+++ b/tests/phpunit/tests/export/uses/nested.php
@@ -40,7 +40,7 @@ class Export_Nested_Function_Use extends Export_UnitTestCase {
 				'name'     => 'do_things',
 				'line'     => 16,
 				'end_line' => 16,
-				'class'    => 'My_Class',
+				'class'    => '\My_Class',
 				'static'   => true,
 			)
 		);
@@ -60,7 +60,7 @@ class Export_Nested_Function_Use extends Export_UnitTestCase {
 				'name'     => 'static_method',
 				'line'     => 11,
 				'end_line' => 11,
-				'class'    => 'My_Class',
+				'class'    => '\My_Class',
 				'static'   => true,
 			)
 		);
@@ -86,7 +86,7 @@ class Export_Nested_Function_Use extends Export_UnitTestCase {
 				'name'     => 'static_method',
 				'line'     => 11,
 				'end_line' => 11,
-				'class'    => 'My_Class',
+				'class'    => '\My_Class',
 				'static'   => true,
 			)
 		);
@@ -132,7 +132,7 @@ class Export_Nested_Function_Use extends Export_UnitTestCase {
 				'name'     => 'do_it',
 				'line'     => 23,
 				'end_line' => 23,
-				'class'    => 'My_Class',
+				'class'    => '\My_Class',
 				'static'   => false,
 			)
 		);
@@ -164,7 +164,7 @@ class Export_Nested_Function_Use extends Export_UnitTestCase {
 				'name'     => 'a_method',
 				'line'     => 29,
 				'end_line' => 29,
-				'class'    => 'My_Class',
+				'class'    => '\My_Class',
 				'static'   => true,
 			)
 		);
@@ -190,7 +190,7 @@ class Export_Nested_Function_Use extends Export_UnitTestCase {
 				'name'     => 'a_method',
 				'line'     => 29,
 				'end_line' => 29,
-				'class'    => 'My_Class',
+				'class'    => '\My_Class',
 				'static'   => true,
 			)
 		);
@@ -201,7 +201,7 @@ class Export_Nested_Function_Use extends Export_UnitTestCase {
 				'name'     => 'do_it',
 				'line'     => 23,
 				'end_line' => 23,
-				'class'    => 'My_Class',
+				'class'    => '\My_Class',
 				'static'   => false,
 			)
 		);


### PR DESCRIPTION
Adds support for PHP Namespaces to the parser. When plugins and themes use namespaces there can be collisions in the parsed function names, and anything else that exists within that namespace. This adds general support for Namespaces in the parser. Namespaces are created as a taxonomy so that you can view what is available in each namespace as an archive page.