### PR TITLE
Stop stripping new lines and instead make parsed post types post_content private

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1,11 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "a6b6b77caa783549c8eda9ef2cc489fb",
-    "content-hash": "81428b7705fd3ea26dd058625d6527c9",
+    "hash": "7f8182189ed845514079dae0bb6fbc34",
     "packages": [
         {
             "name": "composer/installers",

--- a/lib/class-file-reflector.php
+++ b/lib/class-file-reflector.php
@@ -46,7 +46,13 @@ class File_Reflector extends FileReflector {
 	protected $last_doc = null;
 
 	/**
-	 * Grab and store the raw doc comment for the file.
+	 * Grab and store the raw doc comment for the file if present.
+	 *
+	 * Note much of this logic mirrors what is in the parent class for storing
+	 * the file's doc_block key, but it doesn't provide any access to the raw
+	 * text of the comment. Since we are interested in having the raw text
+	 * available, we run the same logic here and store the text  instead of a
+	 * docblock reflection objet.
 	 *
 	 * @param  array  $nodes The nodes that will be traversed in this file.
 	 * @return array         The nodes to traverse for this file.
@@ -89,7 +95,7 @@ class File_Reflector extends FileReflector {
 					&& -1 !== strpos( $comments[0], '@package' ) )
 					|| ! $this->isNodeDocumentable( $node )
 				) {
-					$this->raw_docblock = $comments[0];
+					$this->doc_comment = $comments[0];
 				}
 			}
 		}

--- a/lib/class-file-reflector.php
+++ b/lib/class-file-reflector.php
@@ -4,6 +4,7 @@ namespace WP_Parser;
 
 use phpDocumentor\Reflection;
 use phpDocumentor\Reflection\FileReflector;
+use PHPParser_Comment_Doc;
 
 /**
  * Reflection class for a full file.
@@ -43,6 +44,60 @@ class File_Reflector extends FileReflector {
 	 * @var \PHPParser_Comment_Doc
 	 */
 	protected $last_doc = null;
+
+	/**
+	 * Grab and store the raw doc comment for the file.
+	 *
+	 * @param  array  $nodes The nodes that will be traversed in this file.
+	 * @return array         The nodes to traverse for this file.
+	 */
+	public function beforeTraverse(array $nodes) {
+		$node = null;
+		$key = 0;
+		foreach ($nodes as $k => $n) {
+			if (!$n instanceof PHPParser_Node_Stmt_InlineHTML) {
+				$node = $n;
+				$key = $k;
+				break;
+			}
+		}
+
+		if ($node) {
+			$comments = (array) $node->getAttribute('comments');
+
+			// remove non-DocBlock comments
+			$comments = array_values(
+				array_filter(
+					$comments,
+					function ($comment) {
+						return $comment instanceof PHPParser_Comment_Doc;
+					}
+				)
+			);
+
+			if ( ! empty( $comments ) ) {
+				// the first DocBlock in a file documents the file if
+				// * it precedes another DocBlock or
+				// * it contains a @package tag and doesn't precede a class
+				//   declaration or
+				// * it precedes a non-documentable element (thus no include,
+				//   require, class, function, define, const)
+				if (
+					count( $comments ) > 1
+					|| ( ! $node instanceof PHPParser_Node_Stmt_Class
+					&& ! $node instanceof PHPParser_Node_Stmt_Interface
+					&& -1 !== strpos( $comments[0], '@package' ) )
+					|| ! $this->isNodeDocumentable( $node )
+				) {
+					$this->raw_docblock = $comments[0];
+				}
+			}
+		}
+
+		$nodes = parent::beforeTraverse( $nodes );
+
+		return $nodes;
+	}
 
 	/**
 	 * Add hooks to the queue and update the node stack when we enter a node.

--- a/lib/class-importer.php
+++ b/lib/class-importer.php
@@ -379,15 +379,15 @@ class Importer implements LoggerAwareInterface {
 		$skip_duplicates = apply_filters( 'wp_parser_skip_duplicate_hooks', false );
 
 		if ( false !== $skip_duplicates ) {
-			if ( 0 === strpos( $data['doc']['description'], 'This action is documented in' ) ) {
+			if ( 0 === strpos( $data['doc']['summary'], 'This action is documented in' ) ) {
 				return false;
 			}
 
-			if ( 0 === strpos( $data['doc']['description'], 'This filter is documented in' ) ) {
+			if ( 0 === strpos( $data['doc']['summary'], 'This filter is documented in' ) ) {
 				return false;
 			}
 
-			if ( '' === $data['doc']['description'] && '' === $data['doc']['long_description'] ) {
+			if ( '' === $data['doc']['summary'] && '' === $data['doc']['description'] ) {
 				return false;
 			}
 		}
@@ -517,9 +517,9 @@ class Importer implements LoggerAwareInterface {
 		$post_data   = wp_parse_args(
 			$arg_overrides,
 			array(
-				'post_content'          => $data['doc']['long_description'],
-				'post_content_filtered' => $data['doc']['raw'],
-				'post_excerpt'          => $data['doc']['description'],
+				'post_content'          => $data['doc']['description'],
+				'post_content_filtered' => $data['doc']['raw_description'],
+				'post_excerpt'          => $data['doc']['summary'],
 				'post_name'             => $slug,
 				'post_parent'           => (int) $parent_post_id,
 				'post_status'           => 'publish',
@@ -733,6 +733,7 @@ class Importer implements LoggerAwareInterface {
 			$anything_updated[] = update_post_meta( $post_id, '_wp_parser_namespace', (string) addslashes( $data['namespace'] ) );
 		}
 
+		$anything_updated[] = update_post_meta( $post_id, '_wp_parser_raw_docblock', (string) $data['doc']['raw'] );
 		$anything_updated[] = update_post_meta( $post_id, '_wp-parser_line_num', (string) $data['line'] );
 		$anything_updated[] = update_post_meta( $post_id, '_wp-parser_end_line_num', (string) $data['end_line'] );
 		$anything_updated[] = update_post_meta( $post_id, '_wp-parser_tags', $data['doc']['tags'] );

--- a/lib/class-importer.php
+++ b/lib/class-importer.php
@@ -517,13 +517,14 @@ class Importer implements LoggerAwareInterface {
 		$post_data   = wp_parse_args(
 			$arg_overrides,
 			array(
-				'post_content' => $data['doc']['long_description'],
-				'post_excerpt' => $data['doc']['description'],
-				'post_name'    => $slug,
-				'post_parent'  => (int) $parent_post_id,
-				'post_status'  => 'publish',
-				'post_title'   => $data['name'],
-				'post_type'    => $this->post_type_function,
+				'post_content'          => $data['doc']['long_description'],
+				'post_content_filtered' => $data['doc']['raw'],
+				'post_excerpt'          => $data['doc']['description'],
+				'post_name'             => $slug,
+				'post_parent'           => (int) $parent_post_id,
+				'post_status'           => 'publish',
+				'post_title'            => $data['name'],
+				'post_type'             => $this->post_type_function,
 			)
 		);
 

--- a/lib/class-plugin.php
+++ b/lib/class-plugin.php
@@ -21,6 +21,7 @@ class Plugin {
 
 		add_action( 'init', array( $this, 'register_post_types' ), 11 );
 		add_action( 'init', array( $this, 'register_taxonomies' ), 11 );
+		add_action( 'wp', array( $this, 'replace_autop' ), 11 );
 		add_filter( 'wp_parser_get_arguments', array( $this, 'make_args_safe' ) );
 		add_filter( 'wp_parser_return_type', array( $this, 'humanize_separator' ) );
 
@@ -253,5 +254,44 @@ class Plugin {
 	 */
 	public function humanize_separator( $type ) {
 		return str_replace( '|', '<span class="wp-parser-item-type-or">' . _x( ' or ', 'separator', 'wp-parser' ) . '</span>', $type );
+	}
+
+	/**
+	 * Replaces the normal content autop with a custom version to skip parser types.
+	 *
+	 * By running this filter replacement late on the wp hook, plugins are given ample
+	 * time to remove autop themselves. If they have removed autop, then the maybe_autop
+	 * filter is not added. There are potentially conflicting edge cases, but this
+	 * should catch at least some of them.
+	 *
+	 * Other plugins can also remove this functionality fairly easily by removing the wp
+	 * hook and stopping this process if needed.
+	 */
+	public function replace_autop() {
+		if ( has_filter( 'the_content', 'wpautop' ) ) {
+			remove_filter( 'the_content', 'wpautop' );
+			add_filter( 'the_content', array( $this, 'maybe_autop' ) );
+		}
+	}
+
+	/**
+	 * Autop's all post content except for wp-parser types.
+	 *
+	 * @param  string $content The content to filter.
+	 * @return string          The filtered content, conditionally with autop run.
+	 */
+	public function maybe_autop( $content ) {
+		// Get and cache the blacklist
+		static $blacklist;
+		if ( is_null( $blacklist ) ) {
+			$blacklist = apply_filters( 'wp_parser_autop_blacklist', array(
+				'wp-parser-function' => true,
+				'wp-parser-hook'     => true,
+				'wp-parser-class'    => true,
+				'wp-parser-method'   => true,
+			) );
+		}
+
+		return ( isset( $blacklist[ get_post_type() ] ) ) ? $content : wpautop( $content );
 	}
 }

--- a/lib/class-plugin.php
+++ b/lib/class-plugin.php
@@ -35,7 +35,6 @@ class Plugin {
 		$supports = array(
 			'comments',
 			'custom-fields',
-			'editor',
 			'excerpt',
 			'revisions',
 			'title',

--- a/lib/runner.php
+++ b/lib/runner.php
@@ -149,15 +149,15 @@ function export_docblock( $element ) {
 	}
 
 	$output = array(
-		'description'      => preg_replace( '/[\n\r]+/', ' ', $docblock->getShortDescription() ),
-		'long_description' => preg_replace( '/[\n\r]+/', ' ', $docblock->getLongDescription()->getFormattedContents() ),
+		'description'      => $docblock->getShortDescription(),
+		'long_description' => $docblock->getLongDescription()->getFormattedContents(),
 		'tags'             => array(),
 	);
 
 	foreach ( $docblock->getTags() as $tag ) {
 		$tag_data = array(
 			'name'    => $tag->getName(),
-			'content' => preg_replace( '/[\n\r]+/', ' ', format_description( $tag->getDescription() ) ),
+			'content' => format_description( $tag->getDescription() ),
 		);
 		if ( method_exists( $tag, 'getTypes' ) ) {
 			$tag_data['types'] = $tag->getTypes();
@@ -176,7 +176,7 @@ function export_docblock( $element ) {
 			}
 			// Description string.
 			if ( method_exists( $tag, 'getDescription' ) ) {
-				$description = preg_replace( '/[\n\r]+/', ' ', format_description( $tag->getDescription() ) );
+				$description = format_description( $tag->getDescription() );
 				if ( ! empty( $description ) ) {
 					$tag_data['description'] = $description;
 				}

--- a/lib/runner.php
+++ b/lib/runner.php
@@ -140,7 +140,6 @@ function parse_files( $files, $root ) {
  */
 function export_docblock( $element ) {
 	$docblock = $element->getDocBlock();
-	$raw = '';
 
 	if ( ! $docblock ) {
 		return array(
@@ -151,18 +150,17 @@ function export_docblock( $element ) {
 		);
 	}
 
-	// Pull out the raw docblock if we have it.
-	if ( isset( $element->raw_docblock ) ) {
-		$raw = $element->raw_docblock->getText();
-	} elseif ( $element instanceof BaseReflector ) {
-		$comments = $element->getNode()->getAttribute( 'comments' );
-		if ( $comments && $comments[0] instanceof \PHPParser_Comment_Doc ) {
-			$raw = $comments[0]->getText();
-		}
+	// Extract the raw doc comment
+	if ( $element instanceof BaseReflector ) {
+		$raw_doc = (string) $element->getNode()->getDocComment();
+	} elseif ( $element instanceof File_Reflector && isset( $element->doc_comment ) ) {
+		$raw_doc = (string) $element->doc_comment->getText();
+	} else {
+		$raw_doc = '';
 	}
 
 	$output = array(
-		'raw'              => $raw,
+		'raw'              => $raw_doc,
 		'description'      => $docblock->getShortDescription(),
 		'long_description' => $docblock->getLongDescription()->getFormattedContents(),
 		'tags'             => array(),

--- a/lib/runner.php
+++ b/lib/runner.php
@@ -142,11 +142,12 @@ function export_docblock( $element ) {
 	$docblock = $element->getDocBlock();
 
 	if ( ! $docblock ) {
-		return array(
-			'raw'              => '',
-			'description'      => '',
-			'long_description' => '',
-			'tags'             => array(),
+			return array(
+			'raw'             => '',
+			'summary'         => '',
+			'description'     => '',
+			'raw_description' => '',
+			'tags'            => array(),
 		);
 	}
 
@@ -160,10 +161,11 @@ function export_docblock( $element ) {
 	}
 
 	$output = array(
-		'raw'              => $raw_doc,
-		'description'      => $docblock->getShortDescription(),
-		'long_description' => $docblock->getLongDescription()->getFormattedContents(),
-		'tags'             => array(),
+		'raw'             => $raw_doc,
+		'summary'         => $docblock->getShortDescription(),
+		'description'     => $docblock->getLongDescription()->getFormattedContents(),
+		'raw_description' => $docblock->getLongDescription()->getContents(),
+		'tags'            => array(),
 	);
 
 	foreach ( $docblock->getTags() as $tag ) {

--- a/lib/runner.php
+++ b/lib/runner.php
@@ -140,15 +140,29 @@ function parse_files( $files, $root ) {
  */
 function export_docblock( $element ) {
 	$docblock = $element->getDocBlock();
+	$raw = '';
+
 	if ( ! $docblock ) {
 		return array(
+			'raw'              => '',
 			'description'      => '',
 			'long_description' => '',
 			'tags'             => array(),
 		);
 	}
 
+	// Pull out the raw docblock if we have it.
+	if ( isset( $element->raw_docblock ) ) {
+		$raw = $element->raw_docblock->getText();
+	} elseif ( $element instanceof BaseReflector ) {
+		$comments = $element->getNode()->getAttribute( 'comments' );
+		if ( $comments && $comments[0] instanceof \PHPParser_Comment_Doc ) {
+			$raw = $comments[0]->getText();
+		}
+	}
+
 	$output = array(
+		'raw'              => $raw,
 		'description'      => $docblock->getShortDescription(),
 		'long_description' => $docblock->getLongDescription()->getFormattedContents(),
 		'tags'             => array(),

--- a/tests/phpunit/includes/export-testcase.php
+++ b/tests/phpunit/includes/export-testcase.php
@@ -458,6 +458,38 @@ class Export_UnitTestCase extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * Compact an array of strings to a multi-line string.
+	 *
+	 * @param  array  $lines The array of lines to turn into a multi-line string.
+	 * @return string        The processed multi-line string.
+	 */
+	protected function multiline_string( array $lines ) {
+		return implode( "\n", $lines );
+	}
+
+	/**
+	 * Compact an array of strings into a docblock string.
+	 *
+	 * Takes an array of string, and creates a multi-line string starting with the
+	 * classic docblock /** and ending with the *+/ to close out the docblock. Each
+	 * line will have the whitespace param plus ' * ' added to it.
+	 *
+	 * @param  array  $lines      The array of lines to create a docblock string from.
+	 * @param  string $whitespace Optional. The whitespace to use in the docblocks.
+	 * @return string             The docblock string created from the array of lines.
+	 */
+	protected function make_docblock( array $lines, $whitespace = '' ) {
+		array_walk( $lines, function( &$line ) use ( $whitespace ) {
+			$line = ( empty( $line ) ) ? '' : ' ' . $line;
+			$line = $whitespace . ' *' . $line;
+		});
+		array_unshift( $lines, '/**' );
+		$lines[] = $whitespace . ' */';
+
+		return $this->multiline_string( $lines );
+	}
+
+	/**
 	 * Check if one entity uses another entity.
 	 *
 	 * @param array  $entity The exported entity data.

--- a/tests/phpunit/tests/export/docblocks.php
+++ b/tests/phpunit/tests/export/docblocks.php
@@ -12,25 +12,15 @@ namespace WP_Parser\Tests;
 class Export_Docblocks extends Export_UnitTestCase {
 
 	/**
-	 * Test that line breaks are removed when the description is exported.
-	 */
-	public function test_linebreaks_removed() {
-
-		$this->assertStringMatchesFormat(
-			'%s'
-			, $this->export_data['classes'][0]['doc']['long_description']
-		);
-	}
-
-	/**
 	 * Test that hooks which aren't documented don't receive docs from another node.
 	 */
 	public function test_undocumented_hook() {
 
 		$this->assertHookHasDocs(
-			'undocumented_hook'
-			, array(
-				'description' => '',
+			'undocumented_hook',
+			array(
+				'raw' => '',
+				'summary' => '',
 			)
 		);
 	}
@@ -41,23 +31,53 @@ class Export_Docblocks extends Export_UnitTestCase {
 	public function test_hook_docblocks() {
 
 		$this->assertHookHasDocs(
-			'test_action'
-			, array( 'description' => 'A test action.' )
+			'test_action',
+			array(
+				'raw' => $this->make_docblock( array(
+					'A test action.',
+					'',
+					'@since 3.7.0',
+					'',
+					'@param WP_Post $post Post object.',
+				) ),
+				'summary' => 'A test action.',
+				'tags' => array(
+					array(
+						'name' => 'since',
+						'content' => '3.7.0',
+					),
+					array(
+						'name' => 'param',
+						'types' => array( '\WP_Post' ),
+						'variable' => '$post',
+						'content' => 'Post object.'
+					)
+				)
+			)
 		);
 
 		$this->assertHookHasDocs(
-			'test_filter'
-			, array( 'description' => 'A filter.' )
+			'test_filter',
+			array(
+				'raw' => $this->make_docblock( array( 'A filter.' ) ),
+				'summary' => 'A filter.',
+			)
 		);
 
 		$this->assertHookHasDocs(
-			'test_ref_array_action'
-			, array( 'description' => 'A reference array action.' )
+			'test_ref_array_action',
+			array(
+				'raw' => $this->make_docblock( array( 'A reference array action.' ) ),
+				'summary' => 'A reference array action.',
+			)
 		);
 
 		$this->assertHookHasDocs(
-			'test_ref_array_filter'
-			, array( 'description' => 'A reference array filter.' )
+			'test_ref_array_filter',
+			array(
+				'raw' => $this->make_docblock( array( 'A reference array filter.' ) ),
+				'summary' => 'A reference array filter.'
+			)
 		);
 	}
 
@@ -65,9 +85,35 @@ class Export_Docblocks extends Export_UnitTestCase {
 	 * Test that file-level docs are exported.
 	 */
 	public function test_file_docblocks() {
-
 		$this->assertFileHasDocs(
-			array( 'description' => 'This is the file-level docblock summary.' )
+			array(
+				'raw' => $this->make_docblock( array(
+					'This is the file-level docblock summary.',
+					'',
+					'This is the file-level docblock description, which may span multiple lines. In',
+					'fact, this one does. It spans more than two full lines, continuing on to the',
+					'third line.',
+					'',
+					'@since 1.5.0',
+				) ),
+				'summary' => 'This is the file-level docblock summary.',
+				'description' => $this->multiline_string( array(
+					'<p>This is the file-level docblock description, which may span multiple lines. In',
+					'fact, this one does. It spans more than two full lines, continuing on to the',
+					'third line.</p>',
+				) ),
+				'raw_description' => $this->multiline_string( array(
+					'This is the file-level docblock description, which may span multiple lines. In',
+					'fact, this one does. It spans more than two full lines, continuing on to the',
+					'third line.',
+				) ),
+				'tags' => array(
+					array(
+						'name' => 'since',
+						'content' => '1.5.0',
+					)
+				)
+			)
 		);
 	}
 
@@ -77,10 +123,23 @@ class Export_Docblocks extends Export_UnitTestCase {
 	public function test_function_docblocks() {
 
 		$this->assertFunctionHasDocs(
-			'test_func'
-			, array(
-				'description' => 'This is a function docblock.',
-				'long_description' => '<p>This function is just a test, but we\'ve added this description anyway.</p>',
+			'test_func',
+			array(
+				'raw' => $this->make_docblock( array(
+					'This is a function docblock.',
+					'',
+					'This function is just a test, but we\'ve added this description anyway.',
+					'',
+					'@since 2.6.0',
+					'',
+					'@param string $var A string value.',
+					'@param int    $num A number.',
+					'',
+					'@return bool Whether the function was called correctly.',
+				) ),
+				'summary' => 'This is a function docblock.',
+				'raw_description' => 'This function is just a test, but we\'ve added this description anyway.',
+				'description' => '<p>This function is just a test, but we\'ve added this description anyway.</p>',
 				'tags' => array(
 					array(
 						'name' => 'since',
@@ -114,8 +173,35 @@ class Export_Docblocks extends Export_UnitTestCase {
 	public function test_class_docblocks() {
 
 		$this->assertClassHasDocs(
-			'Test_Class'
-			, array( 'description' => 'This is a class docblock.' )
+			'Test_Class',
+			array(
+				'raw' => $this->make_docblock( array(
+					'This is a class docblock.',
+					'',
+					'This is the more wordy description: This is a comment with two *\'s at the start,',
+					'which means that it is a doc comment. Docblock comments are comment blocks used',
+					'to document code. This one documents the Test_Class class.',
+					'',
+					'@since 3.5.2',
+				) ),
+				'summary' => 'This is a class docblock.',
+				'description' => $this->multiline_string( array(
+					'<p>This is the more wordy description: This is a comment with two *\'s at the start,',
+					'which means that it is a doc comment. Docblock comments are comment blocks used',
+					'to document code. This one documents the Test_Class class.</p>',
+				) ),
+				'raw_description' => $this->multiline_string( array(
+					'This is the more wordy description: This is a comment with two *\'s at the start,',
+					'which means that it is a doc comment. Docblock comments are comment blocks used',
+					'to document code. This one documents the Test_Class class.',
+				) ),
+				'tags' => array(
+					array(
+						'name' => 'since',
+						'content' => '3.5.2',
+					)
+				)
+			)
 		);
 	}
 
@@ -125,9 +211,44 @@ class Export_Docblocks extends Export_UnitTestCase {
 	public function test_method_docblocks() {
 
 		$this->assertMethodHasDocs(
-			'Test_Class'
-			, 'test_method'
-			, array( 'description' => 'This is a method docblock.' )
+			'Test_Class',
+			'test_method',
+			array(
+				'raw' => $this->make_docblock( array(
+					'This is a method docblock.',
+					'',
+					'@since 4.5.0',
+					'',
+					'@param mixed $var A parameter.',
+					'@param array $arr Another parameter.',
+					'',
+					'@return mixed The first param.',
+				), "\t" ),
+				'summary' => 'This is a method docblock.',
+				'tags' => array(
+					array(
+						'name' => 'since',
+						'content' => '4.5.0',
+					),
+					array(
+						'name' => 'param',
+						'types' => array( 'mixed' ),
+						'variable' => '$var',
+						'content' => 'A parameter.',
+					),
+					array(
+						'name' => 'param',
+						'types' => array( 'array' ),
+						'variable' => '$arr',
+						'content' => 'Another parameter.'
+					),
+					array(
+						'name' => 'return',
+						'types' => array( 'mixed' ),
+						'content' => 'The first param.'
+					),
+				),
+			)
 		);
 	}
 
@@ -137,9 +258,11 @@ class Export_Docblocks extends Export_UnitTestCase {
 	public function test_property_docblocks() {
 
 		$this->assertPropertyHasDocs(
-			'Test_Class'
-			, '$a_string'
-			, array( 'description' => 'This is a docblock for a class property.' )
+			'Test_Class',
+			'$a_string',
+			array(
+				'summary' => 'This is a docblock for a class property.'
+			)
 		);
 	}
 }


### PR DESCRIPTION
This fixes the issue where new lines were being stripped from <pre> blocks.

Stripping new lines was a bandaid fix to begin with, and bled through in `<pre>` blocks. Rather than putting a bandaid over a bandaid, this changes the approach. At the same time we look to grab additional data from the parsing. Namely the raw summary and the raw docblock itself.

This is a replacement for the work in #165 which was the bandaid/bandaid fix, but the issue has more history.