### PR TITLE
Include version where available

### DIFF
--- a/lib/runner.php
+++ b/lib/runner.php
@@ -165,7 +165,7 @@ function export_docblock( $element ) {
 		if ( method_exists( $tag, 'getReference' ) ) {
 			$tag_data['refers'] = $tag->getReference();
 		}
-		if ( 'since' == $tag->getName() && method_exists( $tag, 'getVersion' ) ) {
+		if ( method_exists( $tag, 'getVersion' ) ) {
 			// Version string.
 			$version = $tag->getVersion();
 			if ( ! empty( $version ) ) {


### PR DESCRIPTION
 `@since` isn't the only tag that supports a version number - `@deprecated` also does. This patch includes a version whenever its available. 