### PR TITLE
Include link in tag data

### DIFF
--- a/lib/runner.php
+++ b/lib/runner.php
@@ -159,6 +159,9 @@ function export_docblock( $element ) {
 		if ( method_exists( $tag, 'getTypes' ) ) {
 			$tag_data['types'] = $tag->getTypes();
 		}
+		if ( method_exists( $tag, 'getLink' ) ) {
+			$tag_data['link'] = $tag->getLink();
+		}
 		if ( method_exists( $tag, 'getVariableName' ) ) {
 			$tag_data['variable'] = $tag->getVariableName();
 		}


### PR DESCRIPTION
The `@link` tag can be as follows:

    /**
     *@link <url> <text>
     */

But only the `<text>` is passed to `$tag_data`. This patch includes the URL as well.