### PR TITLE
Add handling for deprecated hooks

### DIFF
--- a/lib/class-file-reflector.php
+++ b/lib/class-file-reflector.php
@@ -204,8 +204,10 @@ class File_Reflector extends FileReflector {
 		$functions = array(
 			'apply_filters',
 			'apply_filters_ref_array',
+			'apply_filters_deprecated',
 			'do_action',
 			'do_action_ref_array',
+			'do_action_deprecated',
 		);
 
 		return in_array( $calling, $functions );

--- a/lib/class-hook-reflector.php
+++ b/lib/class-hook-reflector.php
@@ -67,8 +67,14 @@ class Hook_Reflector extends BaseReflector {
 			case 'do_action_ref_array':
 				$type = 'action_reference';
 				break;
+			case 'do_action_deprecated':
+				$type = 'action_deprecated';
+				break;
 			case 'apply_filters_ref_array':
 				$type = 'filter_reference';
+				break;
+			case 'apply_filters_deprecated';
+				$type = 'filter_deprecated';
 				break;
 		}
 

--- a/lib/runner.php
+++ b/lib/runner.php
@@ -335,7 +335,11 @@ function export_uses( array $uses ) {
 						'end_line' => $element->getNode()->getAttribute( 'endLine' ),
 					);
 
-					if ( '_deprecated_file' === $name || '_deprecated_function' === $name || '_deprecated_argument' === $name ) {
+					if ( '_deprecated_file' === $name
+						|| '_deprecated_function' === $name
+						|| '_deprecated_argument' === $name
+						|| '_deprecated_hook' === $name
+					) {
 						$arguments = $element->getNode()->args;
 
 						$out[ $type ][0]['deprecation_version'] = $arguments[1]->value->value;

--- a/lib/template.php
+++ b/lib/template.php
@@ -123,9 +123,34 @@ function arguments_have_default_values() {
  * @return bool
  */
 function is_function_deprecated() {
-	$return = wp_list_filter( get_post_meta( get_the_ID(), '_wp-parser_tags', true ), array( 'name' => 'deprecated' ) );
+	/**
+	 * Filters whether the current function is considered deprecated.
+	 *
+	 * @param bool Whether the current function should be considered deprecated.
+	 */
+	return apply_filters( 'wp_parser_is_function_deprecated', is_deprecated() );
+}
 
-	return apply_filters( 'wp_parser_is_function_deprecated', ! empty( $return ) );
+/**
+ * Determines if the current element is deprecated.
+ *
+ * Works for conceivably any parsed post type that stores DocBlock tag values in meta.
+ *
+ * @return bool Whether the current element is considered deprecated.
+ */
+function is_deprecated() {
+	$tags       = get_post_meta( get_the_ID(), '_wp-parser_tags', true );
+	$deprecated = wp_list_filter( $tags, array( 'name' => 'deprecated' ) );
+
+	$post_type = get_post_type( get_the_ID() );
+
+	/**
+	 * Filters whether the current element is deprecated.
+	 *
+	 * @param bool   $deprecated Whether the current element should be considered deprecated.
+	 * @param string $post_type  Post type for the current element.
+	 */
+	return apply_filters( 'wp_parser_is_deprecated', ! empty( $deprecated ), $post_type );
 }
 
 /**


### PR DESCRIPTION
There is a [proposal](https://core.trac.wordpress.org/ticket/10441#comment:25) up for handling hook deprecation in WordPress core in 4.6+. It introduces three new functions, `apply_filters_deprecated()`, `do_action_deprecated()` and the `_deprecated_hook()` utility function, all of which we need to add handling for in the parser.

**Background:**
Implementation of hook deprecation is essentially a three-prong project in that we need to:
1. Update core – [#10411](https://core.trac.wordpress.org/ticket/10441)
2. Update the parser
3. Update the wporg-developer theme used on the code reference – [#1766](https://meta.trac.wordpress.org/ticket/1766)

Thankfully, the parser is flexible enough already that we don't need to do much to handle deprecated hooks!

Hooks would be deprecated by switching to corresponding `apply_filters|do_action_deprecated()` calls and signatures. Then – just like is already done with functions and methods – pairs of `@deprecated` and `@see` tags will be added to the hook DocBlocks so all deprecate-able elements are handled the same way from a documentation perspective.

**Proposed Changes:**
In this PR I've made the following changes:
- Added `apply_filters_deprecated` and `do_action_deprecated` to the list of functions recognized as "hook" functions
- Introduced two new hook types for use by themes: `filter_deprecated` and `action_deprecated`. These would be in addition the four existing types: `filter`, `filter_reference`, `action`, and `action_reference`, used to identify `apply_filters()`, `apply_filters_ref_array()`, `do_action()`, and `do_action_ref_array()`, respectively.
- Added handling for the new `_deprecated_hook()` function in storing the version the hook was deprecated
- Added a new function (and generic hook), `WP_Parser\is_deprecated()` which can be used for any parsed post type. `WP_Parser\is_function_deprecated()` has been converted into a wrapper for it, and its namesake filter, `wp_parser_is_function_deprecated`, retained for back-compat .
