### PR TITLE
Pick up docs for filters in condition expressions

### DIFF
--- a/tests/phpunit/includes/export-testcase.php
+++ b/tests/phpunit/includes/export-testcase.php
@@ -14,7 +14,7 @@ class Export_UnitTestCase extends \WP_UnitTestCase {
 	/**
 	 * The exported data.
 	 *
-	 * @var string
+	 * @var array
 	 */
 	protected $export_data;
 
@@ -424,8 +424,8 @@ class Export_UnitTestCase extends \WP_UnitTestCase {
 	/**
 	 * Assert that a hook has a docblock.
 	 *
-	 * @param array $hook The hook name.
-	 * @param array $docs The expected data for the hook's docblock.
+	 * @param string $hook The hook name.
+	 * @param array  $docs The expected data for the hook's docblock.
 	 */
 	protected function assertHookHasDocs( $hook, $docs ) {
 
@@ -436,9 +436,9 @@ class Export_UnitTestCase extends \WP_UnitTestCase {
 	/**
 	 * Find the exported data for an entity.
 	 *
-	 * @param array  $data        The data to search in.
-	 * @param string $type        The type of entity.
-	 * @param string $entity_name The name of the function.
+	 * @param array  $data   The data to search in.
+	 * @param string $type   The type of entity.
+	 * @param string $entity The name of the entity.
 	 *
 	 * @return array|false The data for the entity, or false if it couldn't be found.
 	 */

--- a/tests/phpunit/tests/export/docblocks.inc
+++ b/tests/phpunit/tests/export/docblocks.inc
@@ -88,3 +88,13 @@ do_action( 'undocumented_hook' );
  * A reference array action.
  */
 do_action_ref_array( 'test_ref_array_action', array( &$var ) );
+
+/**
+ * A filter in a conditional expression.
+ */
+if ( apply_filters( 'in_conditional_expression', true ) ) {
+	/**
+	 * A filter in a conditional.
+	 */
+	$value = apply_filters( 'in_conditional', true );
+}

--- a/tests/phpunit/tests/export/docblocks.php
+++ b/tests/phpunit/tests/export/docblocks.php
@@ -59,6 +59,16 @@ class Export_Docblocks extends Export_UnitTestCase {
 			'test_ref_array_filter'
 			, array( 'description' => 'A reference array filter.' )
 		);
+
+		$this->assertHookHasDocs(
+			'in_conditional_expression'
+			, array( 'description' => 'A filter in a conditional expression.' )
+		);
+
+		$this->assertHookHasDocs(
+			'in_conditional'
+			, array( 'description' => 'A filter in a conditional.' )
+		);
 	}
 
 	/**


### PR DESCRIPTION
PHPParser loops over the body of a conditional statement (the part between the curly brackets), before looping over each node in the expression. Because we were only saving the last docblock that wasn't associated with a documentable element, if there was also a documented filter within the condition body, the docblock for that filter would be picked up, and the docblock for the first filter in the condition expression would be discarded. So by the time we got to the node for the filter in the condition expression, there was no docblock saved to associate with it.

This is now fixed by keeping a stack of stray docblocks for non-documentable elements, so that instead of the docblock for the first filter being discarded it is just pushed down the stack. The docblock for the second filter within the condition block will be pushed on top of it, and then popped off once it has been used. So when we come around to actually looping over the node for the filter in the conditional expression, its docblock will be at the tip of the stack once again, and can be associated with the filter as expected.

See #185 