### PR TITLE
Use an up to date version of HHVM in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: php
 
 sudo: false
 
+cache:
+  apt: true
+
 matrix:
   include:
     - php: 7.0
@@ -9,6 +12,15 @@ matrix:
     - php: 5.5
     - php: 5.4
     - php: hhvm
+      sudo: required
+      dist: trusty
+      group: edge
+      addons:
+        apt: 
+          packages: 
+            - mysql-server-5.6 
+            - mysql-client-core-5.6 
+            - mysql-client-5.6 
 
 before_install:
     # Setup WP_TESTS_DIR (needed to bootstrap WP PHPUnit tests). 


### PR DESCRIPTION
• The HHVM Travis CI job will now use the latest, currently `HipHop VM 3.17.0 (rel)`, previously it was using `HipHop VM 3.6.6 (rel)`. The HHVM 3.6.x LTS branch end of support was 1 March 2016

• Use MySQL 5.6 for the HHVM job as the default MySQL 5.5 does not currently work on the Trusty environment

• Adds installed apt packages to the cache, in this case MySQL 5.6 for the HHVM job
