### PR TITLE
At the end of a parse, delete 'wp-parser-namespace_children` option so that it gets rebuilt and hierarchical namespace terms are correct.

### DIFF
--- a/lib/class-importer.php
+++ b/lib/class-importer.php
@@ -194,6 +194,7 @@ class Importer implements LoggerAwareInterface {
 		 */
 		delete_option( "{$this->taxonomy_package}_children" );
 		delete_option( "{$this->taxonomy_since_version}_children" );
+		delete_option( "{$this->taxonomy_namespace}_children" );
 
 		/**
 		 * Action at the end of a complete import


### PR DESCRIPTION
This addresses #213.