### PR TITLE
Fix issue #216

### DIFF
--- a/lib/runner.php
+++ b/lib/runner.php
@@ -68,7 +68,7 @@ function parse_files( $files, $root ) {
 
 		foreach ( $file->getIncludes() as $include ) {
 			$out['includes'][] = array(
-				'name' => $include->getName(),
+				'name' => property_exists( $include->getNode()->expr, 'value' ) ? $include->getName() : '',
 				'line' => $include->getLineNumber(),
 				'type' => $include->getType(),
 			);


### PR DESCRIPTION
This version of the PHPDocumentor doesn't validate the presence of the value before accessing it, which throws the error when it's undefined:

https://github.com/phpDocumentor/Reflection/blob/e13a8d8f6f2130f1f1a37ea02b1a76d8a039d10d/src/phpDocumentor/Reflection/IncludeReflector.php#L54-L57

Simply adding the validation fixes the issue.