### PR TITLE
Fix global variables wrongly parsed

### DIFF
--- a/lib/class-file-reflector.php
+++ b/lib/class-file-reflector.php
@@ -126,7 +126,7 @@ class File_Reflector extends FileReflector {
 		// we don't ignore them, we'll end up picking up docblocks that are already
 		// associated with a named element, and so aren't really from a non-
 		// documentable element after all.
-		if ( ! $this->isNodeDocumentable( $node ) && 'Name' !== $node->getType() && ( $docblock = $node->getDocComment() ) ) {
+		if ( ! $this->isNodeDocumentable( $node ) && ! in_array( $node->getType(), array( 'Name', 'Stmt_Global' ), true ) && ( $docblock = $node->getDocComment() ) ) {
 			$this->last_doc = $docblock;
 		}
 	}

--- a/lib/runner.php
+++ b/lib/runner.php
@@ -68,7 +68,7 @@ function parse_files( $files, $root ) {
 
 		foreach ( $file->getIncludes() as $include ) {
 			$out['includes'][] = array(
-				'name' => $include->getName(),
+				'name' => property_exists( $include->getNode()->expr, 'value' ) ? $include->getName() : '',
 				'line' => $include->getLineNumber(),
 				'type' => $include->getType(),
 			);


### PR DESCRIPTION
Fixes issue #230 by checking if the variable is global before assigning it to the `$this->last_doc`.