### PR TITLE
Unit Test: Ensure that apply_filters is extracted, and that the parameters to it are as well.

### DIFF
--- a/tests/phpunit/includes/export-testcase.php
+++ b/tests/phpunit/includes/export-testcase.php
@@ -59,7 +59,13 @@ class Export_UnitTestCase extends \WP_UnitTestCase {
 		foreach ( $entity[ $type ] as $exported ) {
 			if ( $exported['line'] == $expected['line'] ) {
 				foreach ( $expected as $key => $expected_value ) {
-					$this->assertEquals( $expected_value, $exported[ $key ] );
+					if ( isset( $exported[ $key ] ) ) {
+						$exported_value = $exported[ $key ];
+					} else {
+						$exported_value = _wp_array_get( $exported, explode( '.', $key ), null );
+					}
+
+					$this->assertEquals( $expected_value, $exported_value );
 				}
 
 				return;

--- a/tests/phpunit/tests/export/hooks.inc
+++ b/tests/phpunit/tests/export/hooks.inc
@@ -5,3 +5,4 @@ do_action( "action_with_double_quotes" );
 do_action( $variable . '-action' );
 do_action( "another-{$variable}-action" );
 do_action( 'hook_' . $object->property . '_pre' );
+apply_filters( 'plain_filter', $variable, $filter_context );

--- a/tests/phpunit/tests/export/hooks.php
+++ b/tests/phpunit/tests/export/hooks.php
@@ -37,7 +37,13 @@ class Export_Hooks extends Export_UnitTestCase {
 		);
 
 		$this->assertFileContainsHook(
-			array( 'type' => 'apply_filters', 'name' => 'plain_filter', 'line' => 8 )
+			array(
+				'type' => 'filter',
+				'name' => 'plain_filter',
+				'line' => 8,
+				'arguments.0' => '$variable',
+				'arguments.1' => '$filter_context'
+			)
 		);
 	}
 }

--- a/tests/phpunit/tests/export/hooks.php
+++ b/tests/phpunit/tests/export/hooks.php
@@ -35,5 +35,9 @@ class Export_Hooks extends Export_UnitTestCase {
 		$this->assertFileContainsHook(
 			array( 'name' => 'hook_{$object->property}_pre', 'line' => 7 )
 		);
+
+		$this->assertFileContainsHook(
+			array( 'type' => 'apply_filters', 'name' => 'plain_filter', 'line' => 8 )
+		);
 	}
 }


### PR DESCRIPTION
There's a lack of proper unit tests for some aspects of this parser, which makes upgrading the libraries difficult if we've got no baseline.

This adds a unit test for apply_filters() being extracted, and that the variables are properly caught.