### PR TITLE
Derive the plugin directory name in the wp-env scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     "setup": "npm-run-all start start:test composer:setup",
     "start": "wp-env start",
     "start:test": "wp-env --config .wp-env.test.json start",
-    "composer": "wp-env --config .wp-env.test.json run --env-cwd='wp-content/plugins/phpdoc-parser' wordpress composer --no-interaction --no-security-blocking",
-    "composer:setup": "wp-env --config .wp-env.test.json run --env-cwd='wp-content/plugins/phpdoc-parser' wordpress composer install --no-interaction --no-security-blocking",
+    "composer": "wp-env --config .wp-env.test.json run --env-cwd=\"wp-content/plugins/$(basename \"$PWD\")\" wordpress composer --no-interaction --no-security-blocking",
+    "composer:setup": "wp-env --config .wp-env.test.json run --env-cwd=\"wp-content/plugins/$(basename \"$PWD\")\" wordpress composer install --no-interaction --no-security-blocking",
     "test:phpunit:setup": "npm-run-all start:test composer:setup",
-    "test:phpunit": "wp-env --config .wp-env.test.json run --env-cwd='wp-content/plugins/phpdoc-parser' wordpress vendor/phpunit/phpunit/phpunit -c phpunit.xml.dist"
+    "test:phpunit": "wp-env --config .wp-env.test.json run --env-cwd=\"wp-content/plugins/$(basename \"$PWD\")\" wordpress vendor/phpunit/phpunit/phpunit -c phpunit.xml.dist"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The wp-env npm scripts (`composer`, `composer:setup`, `test:phpunit`) hardcode `wp-content/plugins/phpdoc-parser` as the container path. wp-env mounts the checkout under its directory basename, so the scripts break for any checkout not named exactly `phpdoc-parser` — git worktrees, renamed clones.

Derive the path with `$(basename "$PWD")` so the scripts work for any checkout name. Verified by running the suite through `npm run test:phpunit` from a worktree named `phpdoc-parser-pr262-fixes`.

Extracted from #262 to keep that PR focused on export semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)