### PR TITLE
Attach the deprecation version to the deprecating call

### DIFF
--- a/lib/runner.php
+++ b/lib/runner.php
@@ -1292,7 +1292,7 @@ function export_uses( array $uses ) {
 
 				default:
 				case 'functions':
-					$out[ $type ][] = array(
+					$used = array(
 						'name'     => $name,
 						'line'     => $element->getLineNumber(),
 						'end_line' => $element->getNode()->getAttribute( 'endLine' ),
@@ -1310,8 +1310,10 @@ function export_uses( array $uses ) {
 							$version = (string) $arguments[1]->value->value;
 						}
 
-						$out[ $type ][0]['deprecation_version'] = $version;
+						$used['deprecation_version'] = $version;
 					}
+
+					$out[ $type ][] = $used;
 
 					break;
 			}

--- a/tests/phpunit/tests/export/uses/deprecated.inc
+++ b/tests/phpunit/tests/export/uses/deprecated.inc
@@ -1,0 +1,6 @@
+<?php
+
+function old_thing() {
+	do_something_first();
+	_deprecated_function( __FUNCTION__, '6.1.0', 'new_thing' );
+}

--- a/tests/phpunit/tests/export/uses/deprecated.php
+++ b/tests/phpunit/tests/export/uses/deprecated.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * A test case for exporting the version of a deprecation.
+ */
+
+namespace WP_Parser\Tests;
+
+/**
+ * Test that the deprecation version is exported for the deprecating call itself.
+ */
+class Export_Deprecated_Function_Use extends Export_UnitTestCase {
+
+	/**
+	 * Test that the version is exported for the _deprecated_function() call.
+	 */
+	public function test_deprecating_call_has_version() {
+
+		$this->assertFunctionUsesFunction(
+			'old_thing'
+			, array(
+				'name'                => '_deprecated_function',
+				'line'                => 5,
+				'end_line'            => 5,
+				'deprecation_version' => '6.1.0',
+			)
+		);
+	}
+
+	/**
+	 * Test that the version isn't exported for a call preceding the deprecation.
+	 */
+	public function test_preceding_call_has_no_version() {
+
+		$this->assertFunctionUsesFunction(
+			'old_thing'
+			, array(
+				'name'     => 'do_something_first',
+				'line'     => 4,
+				'end_line' => 4,
+			)
+		);
+	}
+}


### PR DESCRIPTION
`export_uses()` writes `deprecation_version` to `$out[ $type ][0]` — the first recorded function use — instead of the `_deprecated_function()` record it belongs to. Any function whose deprecated-call is not the first call in the body exports the version on the wrong record:

```php
function old_thing() {
	do_something_first();
	_deprecated_function( __FUNCTION__, '6.1.0', 'new_thing' );
}
```

exports `uses.functions[0] = { name: 'do_something_first', …, deprecation_version: '6.1.0' }` while the `_deprecated_function` record gets none. It only looks correct in existing fixtures because the deprecated-call happens to come first.

Build the record locally, attach the version to it, and append it once — no positional indexing. The test was added first and fails on master with the version on the wrong entry.

Found during the review of #262 and extracted here as a standalone change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)