### PR TITLE
Fix relationship name-to-post resolution

### DIFF
--- a/lib/class-relationships.php
+++ b/lib/class-relationships.php
@@ -274,6 +274,10 @@ class Relationships {
 
 					// Convert slugs to IDs.
 					if ( empty( $this->slugs_to_ids[ $to_type ] ) ) { // TODO why might this be empty? test class-IXR.php
+						// No posts of this type exist; without a slug map the
+						// raw slug candidates must not reach the connection
+						// loop, where they would be coerced to post ID 1.
+						$this->relationships[ $from_type ][ $from_id ][ $to_type ] = array();
 						continue;
 					}
 
@@ -385,7 +389,7 @@ class Relationships {
 	 *                           namespace, and falling back to the global namespace.
 	 */
 	public function names_to_slugs( $name, $namespace = null ) {
-		$fully_qualified = ( 0 === strpos( '\\', $name ) );
+		$fully_qualified = ( 0 === strpos( $name, '\\' ) );
 		$name = ltrim( $name, '\\' );
 		$names = array();
 
@@ -426,7 +430,7 @@ class Relationships {
 				if ( array_key_exists( $slug, $slugs_to_ids ) ) {
 					$slugs_with_ids[ $slug ] = $slugs_to_ids[ $slug ];
 					// if we found it in this scope, stop searching the chain.
-					continue;
+					break;
 				}
 			}
 		}

--- a/tests/phpunit/tests/relationships.php
+++ b/tests/phpunit/tests/relationships.php
@@ -1,0 +1,125 @@
+<?php
+
+/**
+ * A test case for mapping item names to related posts.
+ */
+
+namespace WP_Parser\Tests;
+
+/**
+ * Test that item names are mapped to related posts correctly.
+ *
+ * @group relationships
+ */
+class Relationships_Test extends \WP_UnitTestCase {
+
+	/**
+	 * The relationships instance under test.
+	 *
+	 * @var \WP_Parser\Relationships
+	 */
+	protected $relationships;
+
+	/**
+	 * Set up before each test.
+	 */
+	public function set_up() {
+
+		parent::set_up();
+
+		$this->relationships = new \WP_Parser\Relationships;
+	}
+
+	/**
+	 * Test that a fully qualified name resolves in the global scope only.
+	 */
+	public function test_names_to_slugs_fully_qualified() {
+
+		$this->assertSame(
+			array( 'foo-bar' )
+			, $this->relationships->names_to_slugs( '\Foo\bar', 'Baz' )
+		);
+	}
+
+	/**
+	 * Test that an unqualified name resolves in the namespace, then globally.
+	 */
+	public function test_names_to_slugs_unqualified() {
+
+		$this->assertSame(
+			array( 'baz-foo-bar', 'foo-bar' )
+			, $this->relationships->names_to_slugs( 'Foo\bar', 'Baz' )
+		);
+	}
+
+	/**
+	 * Test that only the first matching scope for a name produces an ID.
+	 */
+	public function test_get_ids_for_slugs_first_matching_scope_wins() {
+
+		$this->assertSame(
+			array( 'baz-foo' => 5 )
+			, $this->relationships->get_ids_for_slugs(
+				array( array( 'baz-foo', 'foo' ) )
+				, array(
+					'baz-foo' => 5,
+					'foo'     => 7,
+				)
+			)
+		);
+	}
+
+	/**
+	 * Test that a slug with no ID in any scope produces no ID.
+	 */
+	public function test_get_ids_for_slugs_unknown_slug_is_ignored() {
+
+		$this->assertSame(
+			array()
+			, $this->relationships->get_ids_for_slugs(
+				array( array( 'baz-foo', 'foo' ) )
+				, array( 'quux' => 9 )
+			)
+		);
+	}
+
+	/**
+	 * Test that an empty slug map produces no connections at all.
+	 */
+	public function test_ending_import_with_empty_slug_map_makes_no_connections() {
+
+		global $wpdb;
+
+		$this->relationships->wp_parser_starting_import();
+
+		$from_id = self::factory()->post->create(
+			array( 'post_type' => 'wp-parser-function' )
+		);
+
+		$this->relationships->slugs_to_ids  = array();
+		$this->relationships->relationships = array(
+			'wp-parser-function' => array(
+				$from_id => array(
+					'wp-parser-function' => array( array( 'baz-foo', 'foo' ) ),
+				),
+			),
+		);
+
+		$this->relationships->wp_parser_ending_import();
+
+		// The unresolvable slugs must not survive as raw candidate arrays.
+		$this->assertSame(
+			array()
+			, $this->relationships->relationships['wp-parser-function'][ $from_id ]['wp-parser-function']
+		);
+
+		$connections = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT * FROM {$wpdb->prefix}p2p WHERE p2p_from = %d"
+				, $from_id
+			)
+		);
+
+		$this->assertSame( array(), $connections );
+	}
+}


### PR DESCRIPTION
Three bugs in `lib/class-relationships.php` broke the name→slug→post-ID resolution that builds p2p connections:

1. **`names_to_slugs()` never detects fully qualified names.** `strpos( '\\', $name )` has haystack and needle swapped, so `$fully_qualified` is always false and a `\`-prefixed call is still resolved against the current namespace first. PHP semantics say a fully qualified name resolves only globally; now it does. This deliberately changes candidate order for `\`-qualified calls made inside a namespace.

2. **`get_ids_for_slugs()` connects every matching scope.** The loop says "stop searching the chain" but uses `continue`, so when both the namespace-scoped and the global candidate resolve to posts, both are connected — duplicate/spurious p2p connections. Now the first (most specific) match wins.

3. **An empty slug map connects items to post ID 1.** When no posts of a target type were imported, the raw array-of-candidate-arrays was left in `$relationships`, and the connection loop's `intval( array, 10 )` coerces each to `1` — connecting items to whatever post has ID 1. The candidates are now cleared so nothing reaches the connection loop. This is the `TODO why might this be empty? test class-IXR.php` spot.

The new tests fail on master (3 of 5; the other two pin existing correct behavior) and pass with the fix; the full suite passes.

Observed while here, left alone: the methods branches of the connection loop pass `'data' => current_time( 'mysql' )` where the functions branches pass `'date' =>` — looks like a typo, but changing stored p2p meta is out of scope for this fix.

Found by the multi-agent review during #262; extracted as a standalone change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)