### PR TITLE
Detect the _deprecated_file() call anywhere in a file's uses

### DIFF
--- a/lib/class-importer.php
+++ b/lib/class-importer.php
@@ -297,13 +297,18 @@ class Importer implements LoggerAwareInterface {
 		// Detect deprecated file
 		$deprecated_file = false;
 		if ( isset( $file['uses']['functions'] ) ) {
-			$first_function = $file['uses']['functions'][0];
+			foreach ( $file['uses']['functions'] as $function_use ) {
 
-			// If the first function in this file is _deprecated_function
-			if ( '_deprecated_file' === $first_function['name'] ) {
+				// The file is deprecated if it calls _deprecated_file()
+				if ( isset( $function_use['name'] ) && '_deprecated_file' === $function_use['name'] ) {
 
-				// Set the deprecated flag to the version number
-				$deprecated_file = $first_function['deprecation_version'];
+					// Set the deprecated flag to the version number
+					if ( isset( $function_use['deprecation_version'] ) ) {
+						$deprecated_file = $function_use['deprecation_version'];
+					}
+
+					break;
+				}
 			}
 		}
 

--- a/tests/phpunit/tests/import/deprecated-file.inc
+++ b/tests/phpunit/tests/import/deprecated-file.inc
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * File summary.
+ *
+ * @package Something
+ */
+
+/**
+ * This function is here to receive the file's deprecated tag.
+ *
+ * @since 1.0.0
+ */
+function wp_parser_deprecated_file_test_func() {}

--- a/tests/phpunit/tests/import/deprecated-file.php
+++ b/tests/phpunit/tests/import/deprecated-file.php
@@ -1,0 +1,134 @@
+<?php
+
+/**
+ * Test for detecting deprecated files during import.
+ */
+
+namespace WP_Parser\Tests;
+
+/**
+ * Test that a file's _deprecated_file() call deprecates its items on import.
+ *
+ * @group import
+ */
+class Deprecated_File_Import_Test extends Export_UnitTestCase {
+
+	/**
+	 * Import the parsed fixture with the given file-level function uses.
+	 *
+	 * @param array $functions_used Export data for the file's function uses.
+	 *
+	 * @return array The imported function post's tags meta.
+	 */
+	protected function import_with_file_uses( $functions_used ) {
+
+		$file_data = $this->export_data;
+		$file_data['uses']['functions'] = $functions_used;
+
+		$importer = new \WP_Parser\Importer;
+		$importer->import( array( $file_data ) );
+
+		$posts = get_posts(
+			array(
+				'post_type' => $importer->post_type_function,
+				'name'      => 'wp_parser_deprecated_file_test_func',
+			)
+		);
+
+		$this->assertCount( 1, $posts );
+
+		return get_post_meta( $posts[0]->ID, '_wp-parser_tags', true );
+	}
+
+	/**
+	 * Test that a file deprecated by its first call is detected.
+	 */
+	public function test_deprecating_first_call_is_detected() {
+
+		$tags = $this->import_with_file_uses(
+			array(
+				array(
+					'name'                => '_deprecated_file',
+					'line'                => 3,
+					'end_line'            => 3,
+					'deprecation_version' => '2.0.0',
+				),
+			)
+		);
+
+		$this->assertArrayHasKey( 'deprecated', $tags );
+		$this->assertSame( '2.0.0', $tags['deprecated'] );
+	}
+
+	/**
+	 * Test that the deprecating call is detected after preceding calls.
+	 */
+	public function test_deprecating_call_after_other_calls_is_detected() {
+
+		$tags = $this->import_with_file_uses(
+			array(
+				array(
+					'name'     => 'do_something_first',
+					'line'     => 3,
+					'end_line' => 3,
+				),
+				array(
+					'name'                => '_deprecated_file',
+					'line'                => 4,
+					'end_line'            => 4,
+					'deprecation_version' => '2.0.0',
+				),
+			)
+		);
+
+		$this->assertArrayHasKey( 'deprecated', $tags );
+		$this->assertSame( '2.0.0', $tags['deprecated'] );
+	}
+
+	/**
+	 * Test that a file without a deprecating call is not deprecated.
+	 */
+	public function test_file_without_deprecating_call_is_not_deprecated() {
+
+		$tags = $this->import_with_file_uses(
+			array(
+				array(
+					'name'     => 'do_something_first',
+					'line'     => 3,
+					'end_line' => 3,
+				),
+			)
+		);
+
+		$this->assertArrayNotHasKey( 'deprecated', $tags );
+	}
+
+	/**
+	 * Test that a deprecating call without a version does not deprecate.
+	 */
+	public function test_deprecating_call_without_version_is_not_deprecated() {
+
+		$tags = $this->import_with_file_uses(
+			array(
+				array(
+					'name'                => '_deprecated_file',
+					'line'                => 3,
+					'end_line'            => 3,
+					'deprecation_version' => null,
+				),
+			)
+		);
+
+		$this->assertArrayNotHasKey( 'deprecated', $tags );
+	}
+
+	/**
+	 * Test that a file with an empty uses list imports without error.
+	 */
+	public function test_empty_uses_list_is_not_deprecated() {
+
+		$tags = $this->import_with_file_uses( array() );
+
+		$this->assertArrayNotHasKey( 'deprecated', $tags );
+	}
+}


### PR DESCRIPTION
The importer flags a file as deprecated only when `uses.functions[0]` — the first recorded call in the file — is `_deprecated_file()`. Any call preceding it silently loses the deprecation flag, and an empty uses list raises an undefined-offset notice. The importer now searches the uses list for the `_deprecated_file` record and reads `deprecation_version` from that record.

Complements #277, which makes the exporter attach `deprecation_version` to the deprecating call's own record instead of index 0. With pre-#277 export data where the deprecating call isn't first, the version sits on the wrong record and the file stays unflagged — the same outcome as today, so this change is non-regressing under either exporter and becomes fully correct once #277 lands. The tests feed hand-built uses data to the importer, so they exercise the importer's contract without depending on the exporter's placement.

The after-other-calls test and the empty-uses test fail on master (one missed flag, one undefined-offset error); all pass with the fix, as does the full suite.

Found during the review of #262; extracted as a standalone change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)