### PR TITLE
Map global variable receivers to their classes

### DIFF
--- a/lib/class-method-call-reflector.php
+++ b/lib/class-method-call-reflector.php
@@ -89,35 +89,37 @@ class Method_Call_Reflector extends BaseReflector {
 	 */
 	protected function _getClassMapping() {
 
+		// Keys are receiver expressions as printed by the pretty printer, so
+		// global variables keep their `$` sigil.
 		// List of global use generated using following command:
-		// ack "global \\\$[^;]+;" --no-filename | tr -d '\t' | sort | uniq | sed "s/global //g" | sed "s/, /,/g" | tr , '\n' | sed "s/;//g" | sort | uniq | sed "s/\\\$//g" | sed "s/[^ ][^ ]*/'&' => ''/g"
+		// ack "global \\\$[^;]+;" --no-filename | tr -d '\t' | sort | uniq | sed "s/global //g" | sed "s/, /,/g" | tr , '\n' | sed "s/;//g" | sort | uniq | sed "s/[^ ][^ ]*/'&' => ''/g"
 		// There is probably an easier way, there are currently no globals that are classes starting with an underscore
 		$wp_globals = array(
-			'authordata' => 'WP_User',
-			'custom_background' => 'Custom_Background',
-			'custom_image_header' => 'Custom_Image_Header',
-			'phpmailer' => 'PHPMailer',
-			'post' => 'WP_Post',
-			'userdata' => 'WP_User', // This can also be stdClass, but you can't call methods on an stdClass
-			'wp' => 'WP',
-			'wp_admin_bar' => 'WP_Admin_Bar',
-			'wp_customize' => 'WP_Customize_Manager',
-			'wp_embed' => 'WP_Embed',
-			'wp_filesystem' => 'WP_Filesystem',
-			'wp_hasher' => 'PasswordHash', // This can be overridden by plugins, for core assume this is ours
-			'wp_json' => 'Services_JSON',
-			'wp_list_table' => 'WP_List_Table', // This one differs because there are a lot of different List Tables, assume they all only overwrite existing functions on WP_List_Table
-			'wp_locale' => 'WP_Locale',
-			'wp_object_cache' => 'WP_Object_Cache',
-			'wp_query' => 'WP_Query',
-			'wp_rewrite' => 'WP_Rewrite',
-			'wp_roles' => 'WP_Roles',
-			'wp_scripts' => 'WP_Scripts',
-			'wp_styles' => 'WP_Styles',
-			'wp_the_query' => 'WP_Query',
-			'wp_widget_factory' => 'WP_Widget_Factory',
-			'wp_xmlrpc_server' => 'wp_xmlrpc_server', // This can be overridden by plugins, for core assume this is ours
-			'wpdb' => 'wpdb',
+			'$authordata' => 'WP_User',
+			'$custom_background' => 'Custom_Background',
+			'$custom_image_header' => 'Custom_Image_Header',
+			'$phpmailer' => 'PHPMailer',
+			'$post' => 'WP_Post',
+			'$userdata' => 'WP_User', // This can also be stdClass, but you can't call methods on an stdClass
+			'$wp' => 'WP',
+			'$wp_admin_bar' => 'WP_Admin_Bar',
+			'$wp_customize' => 'WP_Customize_Manager',
+			'$wp_embed' => 'WP_Embed',
+			'$wp_filesystem' => 'WP_Filesystem',
+			'$wp_hasher' => 'PasswordHash', // This can be overridden by plugins, for core assume this is ours
+			'$wp_json' => 'Services_JSON',
+			'$wp_list_table' => 'WP_List_Table', // This one differs because there are a lot of different List Tables, assume they all only overwrite existing functions on WP_List_Table
+			'$wp_locale' => 'WP_Locale',
+			'$wp_object_cache' => 'WP_Object_Cache',
+			'$wp_query' => 'WP_Query',
+			'$wp_rewrite' => 'WP_Rewrite',
+			'$wp_roles' => 'WP_Roles',
+			'$wp_scripts' => 'WP_Scripts',
+			'$wp_styles' => 'WP_Styles',
+			'$wp_the_query' => 'WP_Query',
+			'$wp_widget_factory' => 'WP_Widget_Factory',
+			'$wp_xmlrpc_server' => 'wp_xmlrpc_server', // This can be overridden by plugins, for core assume this is ours
+			'$wpdb' => 'wpdb',
 		);
 
 		$wp_functions = array(

--- a/tests/phpunit/tests/export/uses/methods.inc
+++ b/tests/phpunit/tests/export/uses/methods.inc
@@ -19,3 +19,5 @@ class My_Class extends Parent_Class {
 		parent::do_parental_stuff();
 	}
 }
+
+$wp_the_query->get( 'paged' );

--- a/tests/phpunit/tests/export/uses/methods.php
+++ b/tests/phpunit/tests/export/uses/methods.php
@@ -84,7 +84,17 @@ class Export_Method_Use extends Export_UnitTestCase {
 				'name'     => 'update',
 				'line'     => 5,
 				'end_line' => 5,
-				'class'    => '$wpdb',
+				'class'    => 'wpdb',
+				'static'   => false,
+			)
+		);
+
+		$this->assertFileUsesMethod(
+			array(
+				'name'     => 'get',
+				'line'     => 23,
+				'end_line' => 23,
+				'class'    => 'WP_Query',
 				'static'   => false,
 			)
 		);


### PR DESCRIPTION
`Method_Call_Reflector::_getClassMapping()` maps well-known WordPress globals to their classes with keys like `'wpdb'`, but the pretty-printed receiver it is matched against is `'$wpdb'` — the comment documenting the list's generation even shows the `sed "s/\\$//g"` stage that stripped the sigils. The `$wp_globals` half of the mapping has therefore never matched; the existing test pinned the fallout (`class => '$wpdb'`), evidently unintentionally. The `$wp_functions` half (`get_current_screen()` → `WP_Screen`) was unaffected.

The keys now carry the `$` sigil, so the mapping matches. This is a deliberate behavior change to exported `uses.methods[].class` for calls on these globals:

- Where the variable name differs from the class — `$wp_the_query`, `$post`, `$authordata`, `$userdata`, `$wp_customize`, `$wp_hasher`, `$wp_json`, `$phpmailer`, `$custom_background`, `$custom_image_header` — the exported class (and thus the method slug built from it) now points at the real method post. Those cross-links have been broken all along.
- Where they coincide (`$wpdb`, `$wp_query`, …) only the exported string changes (`$wpdb` → `wpdb`); the link slug was already rescued by `sanitize_title()` dropping the `$`.

The alternative — deleting the dead half — was considered and rejected: the mapping repairs real cross-links. A corpus regeneration diff will show class-name changes for these receivers; they are intended.

The updated `$wpdb` expectation and the new `$wp_the_query` → `WP_Query` assertion fail on master and pass with the fix; the full suite passes.

Found by the multi-agent review during #262; extracted as a standalone change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)