### PR TITLE
Pass --no-security-blocking only to composer install

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "setup": "npm-run-all start start:test composer:setup",
     "start": "wp-env start",
     "start:test": "wp-env --config .wp-env.test.json start",
-    "composer": "wp-env --config .wp-env.test.json run --env-cwd='wp-content/plugins/phpdoc-parser' wordpress composer --no-interaction --no-security-blocking",
+    "composer": "wp-env --config .wp-env.test.json run --env-cwd='wp-content/plugins/phpdoc-parser' wordpress composer --no-interaction",
     "composer:setup": "wp-env --config .wp-env.test.json run --env-cwd='wp-content/plugins/phpdoc-parser' wordpress composer install --no-interaction --no-security-blocking",
     "test:phpunit:setup": "npm-run-all start:test composer:setup",
     "test:phpunit": "wp-env --config .wp-env.test.json run --env-cwd='wp-content/plugins/phpdoc-parser' wordpress vendor/phpunit/phpunit/phpunit -c phpunit.xml.dist"


### PR DESCRIPTION
`--no-security-blocking` is an install/update option, but the generic `composer` passthrough script passes it to every command, so anything else fails — e.g. `npm run composer -- validate`. The flag stays on `composer:setup` (install), and the passthrough keeps only `--no-interaction`.

Verified in the PHP 7.4 wordpress container: `composer --no-interaction --no-security-blocking validate` exits 1; without the flag it reports `./composer.json is valid`. `composer install --no-interaction --no-security-blocking` continues to work (unchanged `composer:setup` path).

Overlaps trivially with #276, which rewrites the same lines to derive the plugin directory; whichever lands second rebases in seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)