### PR TITLE
Pin verbatim export of snippet and Blueprint source

### DIFF
--- a/lib/class-command.php
+++ b/lib/class-command.php
@@ -152,7 +152,14 @@ class Command extends WP_CLI_Command {
 		$output = parse_files( $files, $path );
 
 		if ( 'json' == $format ) {
-			return json_encode( $output, JSON_PRETTY_PRINT );
+			$json = json_encode( $output, JSON_PRETTY_PRINT );
+
+			if ( false === $json ) {
+				WP_CLI::error( sprintf( 'Problem encoding the data from %1$s as JSON: %2$s', $path, json_last_error_msg() ) );
+				exit;
+			}
+
+			return $json;
 		}
 
 		return $output;

--- a/lib/class-hook-reflector.php
+++ b/lib/class-hook-reflector.php
@@ -10,14 +10,15 @@ use phpDocumentor\Reflection\BaseReflector;
 class Hook_Reflector extends BaseReflector {
 
 	/**
+	 * Get the hook name as it is spelled in the source.
+	 *
+	 * The name is printed from the source expression instead of read from the
+	 * interpreted string value. Interpreting escape sequences may produce bytes
+	 * that are not valid UTF-8, which cannot be encoded as JSON.
+	 *
 	 * @return string
 	 */
 	public function getName() {
-		$name = $this->node->args[0]->value;
-		if ( $name instanceof \PhpParser\Node\Scalar\String_ ) {
-			return $name->value;
-		}
-
 		$printer = new Pretty_Printer();
 		return $this->cleanupName( $printer->prettyPrintExpr( $this->node->args[0]->value ) );
 	}

--- a/lib/class-hook-reflector.php
+++ b/lib/class-hook-reflector.php
@@ -32,8 +32,10 @@ class Hook_Reflector extends BaseReflector {
 		$matches = array();
 
 		// quotes on both ends of a string
-		if ( preg_match( '/^[\'"]([^\'"]*)[\'"]$/', $name, $matches ) ) {
-			return $matches[1];
+		// The quoted body may contain the other quote character, as in "it's",
+		// or an escaped copy of the quote that delimits it, as in 'it\'s'.
+		if ( preg_match( '/^([\'"])((?:(?!\1)[^\\\\]|\\\\.)*)\1$/s', $name, $matches ) ) {
+			return $matches[2];
 		}
 
 		// two concatenated things, last one of them a variable

--- a/lib/class-hook-reflector.php
+++ b/lib/class-hook-reflector.php
@@ -13,6 +13,11 @@ class Hook_Reflector extends BaseReflector {
 	 * @return string
 	 */
 	public function getName() {
+		$name = $this->node->args[0]->value;
+		if ( $name instanceof \PhpParser\Node\Scalar\String_ ) {
+			return $name->value;
+		}
+
 		$printer = new \PhpParser\PrettyPrinter\Standard();
 		return $this->cleanupName( $printer->prettyPrintExpr( $this->node->args[0]->value ) );
 	}

--- a/lib/class-hook-reflector.php
+++ b/lib/class-hook-reflector.php
@@ -18,7 +18,7 @@ class Hook_Reflector extends BaseReflector {
 			return $name->value;
 		}
 
-		$printer = new \PhpParser\PrettyPrinter\Standard();
+		$printer = new Pretty_Printer();
 		return $this->cleanupName( $printer->prettyPrintExpr( $this->node->args[0]->value ) );
 	}
 

--- a/lib/class-pretty-printer.php
+++ b/lib/class-pretty-printer.php
@@ -5,7 +5,24 @@ namespace WP_Parser;
 /**
  * Extends default printer for arguments.
  */
-class Pretty_Printer extends \PhpParser\PrettyPrinter\Standard {
+class Pretty_Printer extends \phpDocumentor\Reflection\PrettyPrinter {
+	/**
+	 * Print names as they appeared before PHP-Parser's name resolution.
+	 *
+	 * PHP-Parser represents resolved global names as fully-qualified names. The
+	 * leading namespace separator is useful in an AST, but adding it to exported
+	 * source expressions changes the established JSON output.
+	 *
+	 * @param \PhpParser\Node\Name\FullyQualified $node Fully-qualified name.
+	 *
+	 * @return string Printed name.
+	 */
+	protected function pName_FullyQualified( \PhpParser\Node\Name\FullyQualified $node ): string {
+		$name = $node->toString();
+
+		return false === strpos( $name, '\\' ) ? $name : '\\' . $name;
+	}
+
 	/**
 	 * Pretty prints an argument.
 	 *

--- a/lib/class-pretty-printer.php
+++ b/lib/class-pretty-printer.php
@@ -13,6 +13,13 @@ class Pretty_Printer extends \phpDocumentor\Reflection\PrettyPrinter {
 	 * leading namespace separator is useful in an AST, but adding it to exported
 	 * source expressions changes the established JSON output.
 	 *
+	 * Single-segment fully-qualified names are therefore printed without the
+	 * leading backslash. Inside a namespaced file the printed form denotes a
+	 * namespaced symbol rather than the global one, for example `\Foo::BAR` is
+	 * printed as `Foo::BAR`, which in a namespaced file would resolve to
+	 * `Vendor\Foo::BAR`. This is an accepted limitation because the parser
+	 * targets global-namespace WordPress core code.
+	 *
 	 * @param \PhpParser\Node\Name\FullyQualified $node Fully-qualified name.
 	 *
 	 * @return string Printed name.

--- a/lib/class-pretty-printer.php
+++ b/lib/class-pretty-printer.php
@@ -24,6 +24,32 @@ class Pretty_Printer extends \phpDocumentor\Reflection\PrettyPrinter {
 	}
 
 	/**
+	 * Print heredoc and nowdoc strings with their delimiters.
+	 *
+	 * The parent printer returns PHP-Parser's `rawValue` attribute so that
+	 * escape sequences are not interpreted. For heredoc and nowdoc strings that
+	 * attribute holds the body only, without the `<<<LABEL` delimiters, which is
+	 * no longer a PHP expression. Those are printed by the default printer,
+	 * which does not interpret escape sequences in doc strings either.
+	 *
+	 * @param \PhpParser\Node\Scalar\String_ $node String.
+	 *
+	 * @return string Printed string.
+	 */
+	public function pScalar_String( \PhpParser\Node\Scalar\String_ $node ): string {
+		$kind = $node->getAttribute( 'kind' );
+
+		if (
+			\PhpParser\Node\Scalar\String_::KIND_HEREDOC === $kind ||
+			\PhpParser\Node\Scalar\String_::KIND_NOWDOC === $kind
+		) {
+			return \PhpParser\PrettyPrinter\Standard::pScalar_String( $node );
+		}
+
+		return parent::pScalar_String( $node );
+	}
+
+	/**
 	 * Pretty prints an argument.
 	 *
 	 * @param \PhpParser\Node\Arg $node Expression argument

--- a/lib/runner.php
+++ b/lib/runner.php
@@ -102,7 +102,7 @@ function parse_files( $files, $root ) {
 				$func = array(
 					'name'      => $function->getShortName(),
 					'namespace' => $function->getNamespace(),
-					'aliases'   => $function->getNamespaceAliases(),
+					'aliases'   => strip_global_namespace_prefixes( $function->getNamespaceAliases() ),
 					'line'      => $function->getLineNumber(),
 					'end_line'  => $function->getNode()->getAttribute( 'endLine' ),
 					'arguments' => export_arguments( $function->getArguments() ),
@@ -132,8 +132,8 @@ function parse_files( $files, $root ) {
 					'end_line'   => $class->getNode()->getAttribute( 'endLine' ),
 					'final'      => $class->isFinal(),
 					'abstract'   => $class->isAbstract(),
-					'extends'    => $class->getParentClass(),
-					'implements' => $class->getInterfaces(),
+					'extends'    => strip_global_namespace_prefix( $class->getParentClass() ),
+					'implements' => strip_global_namespace_prefixes( $class->getInterfaces() ),
 					'properties' => export_properties( $class->getProperties(), $class_setup_blueprints, $path ),
 					'methods'    => export_methods( $class->getMethods(), $class_setup_blueprints, $path ),
 					'doc'        => $class_doc,
@@ -149,32 +149,41 @@ function parse_files( $files, $root ) {
 		throw $e;
 	}
 
-	/*
-	 * nikic/php-parser in version 3 started adding a namespace prefix
-	 * at the start of global names, but this is different than how the
-	 * documentation was previously generated. This removes those prefixes
-	 * only at the start of an output value so embedded reverse soliduses (\)
-	 * in documentation and other source text remain untouched.
-	 */
-	array_walk_recursive(
-		$output,
-		static function( &$value ) {
-			if ( is_string( $value ) ) {
-				// "\wp_kses()" -> "wp_kses()"
-				$without_global_namespace = preg_replace(
-					'~^\\\\([A-Z_a-z\x80-\xFF][0-9A-Z_a-z\x80-\xFF]*)([:(\p{Z}]|->|$)~',
-					'$1$2',
-					$value,
-				);
-
-				if ( $value !== $without_global_namespace ) {
-					$value = $without_global_namespace;
-				}
-			}
-		}
-	);
-
 	return $output;
+}
+
+/**
+ * Remove a synthetic leading namespace prefix from a global name.
+ *
+ * @param mixed $name Name to normalize.
+ *
+ * @return mixed
+ */
+function strip_global_namespace_prefix( $name ) {
+	if ( ! is_string( $name ) ) {
+		return $name;
+	}
+
+	return preg_replace(
+		'~^\\\\([A-Z_a-z\x80-\xFF][0-9A-Z_a-z\x80-\xFF]*)([:(\p{Z}]|->|$)~',
+		'$1$2',
+		$name
+	);
+}
+
+/**
+ * Remove synthetic leading namespace prefixes from global names.
+ *
+ * @param array $names Names to normalize.
+ *
+ * @return array
+ */
+function strip_global_namespace_prefixes( array $names ) {
+	foreach ( $names as $key => $name ) {
+		$names[ $key ] = strip_global_namespace_prefix( $name );
+	}
+
+	return $names;
 }
 
 /**
@@ -529,7 +538,7 @@ function export_docblock( $element, array $inherited_setup_blueprints = array(),
 			'content' => preg_replace( '/[\n\r]+/', ' ', format_description( $tag->getDescription() ) ),
 		);
 		if ( method_exists( $tag, 'getTypes' ) ) {
-			$tag_data['types'] = $tag->getTypes();
+			$tag_data['types'] = strip_global_namespace_prefixes( $tag->getTypes() );
 		}
 		if ( method_exists( $tag, 'getLink' ) ) {
 			$tag_data['link'] = $tag->getLink();
@@ -697,7 +706,7 @@ function export_arguments( array $arguments ) {
 		$output[] = array(
 			'name'    => $argument->getName(),
 			'default' => $argument->getDefault(),
-			'type'    => $argument->getType(),
+			'type'    => strip_global_namespace_prefix( $argument->getType() ),
 		);
 	}
 
@@ -745,7 +754,7 @@ function export_methods( array $methods, array $inherited_setup_blueprints = arr
 		$method_data = array(
 			'name'       => $method->getShortName(),
 			'namespace'  => $method->getNamespace(),
-			'aliases'    => $method->getNamespaceAliases(),
+			'aliases'    => strip_global_namespace_prefixes( $method->getNamespaceAliases() ),
 			'line'       => $method->getLineNumber(),
 			'end_line'   => $method->getNode()->getAttribute( 'endLine' ),
 			'final'      => $method->isFinal(),
@@ -1282,7 +1291,7 @@ function export_uses( array $uses ) {
 				case 'methods':
 					$out[ $type ][] = array(
 						'name'     => $name[1],
-						'class'    => $name[0],
+						'class'    => strip_global_namespace_prefix( $name[0] ),
 						'static'   => $element->isStatic(),
 						'line'     => $element->getLineNumber(),
 						'end_line' => $element->getNode()->getAttribute( 'endLine' ),
@@ -1291,6 +1300,7 @@ function export_uses( array $uses ) {
 
 				default:
 				case 'functions':
+					$name = strip_global_namespace_prefix( $name );
 					$out[ $type ][] = array(
 						'name'     => $name,
 						'line'     => $element->getLineNumber(),

--- a/lib/runner.php
+++ b/lib/runner.php
@@ -210,12 +210,27 @@ function export_expression( $expression ) {
 /**
  * Remove synthetic global namespace prefixes from inline DocBlock references.
  *
+ * A special exception is made for text appearing in `<code>` and `<pre>` tags, as code
+ * samples are reproduced verbatim and any prefix appearing in them was written by hand.
+ *
  * @param string $text Formatted DocBlock text.
  *
  * @return string
  */
 function strip_global_namespace_prefixes_from_inline_references( $text ) {
-	return preg_replace_callback(
+	// Non-naturally occurring string to use as temporary replacement.
+	$replacement_string = '{{{{{}}}}}';
+
+	// Replace inline tag openings within 'code' and 'pre' tags with replacement string.
+	$text = preg_replace_callback(
+		"/(<code[^>]*>)(.+)(?=<\/code>)/sU",
+		function ( $matches ) use ( $replacement_string ) {
+			return str_replace( '{@', $replacement_string, $matches[1] . $matches[2] );
+		},
+		$text
+	);
+
+	$text = preg_replace_callback(
 		'~{@(?:link|see)\s+([^}\s]+)~',
 		static function( $matches ) {
 			return str_replace(
@@ -226,6 +241,9 @@ function strip_global_namespace_prefixes_from_inline_references( $text ) {
 		},
 		$text
 	);
+
+	// Restore inline tag openings into code blocks.
+	return str_replace( $replacement_string, '{@', $text );
 }
 
 /**

--- a/lib/runner.php
+++ b/lib/runner.php
@@ -152,10 +152,9 @@ function parse_files( $files, $root ) {
 	/*
 	 * nikic/php-parser in version 3 started adding a namespace prefix
 	 * at the start of global names, but this is different than how the
-	 * documentation was previously generated. this removes those prefixes
-	 * by removing a leading reverse solidus (\) when no other reverse
-	 * solidus appears before the end of a sequence of PHP identifier
-	 * characters.
+	 * documentation was previously generated. This removes those prefixes
+	 * only at the start of an output value so embedded reverse soliduses (\)
+	 * in documentation and other source text remain untouched.
 	 */
 	array_walk_recursive(
 		$output,
@@ -163,8 +162,8 @@ function parse_files( $files, $root ) {
 			if ( is_string( $value ) ) {
 				// "\wp_kses()" -> "wp_kses()"
 				$without_global_namespace = preg_replace(
-					'~(^|\p{Z})\\\\([A-Z_a-z\x80-\xFF][0-9A-Z_a-z\x80-\xFF]*)([:(\p{Z}]|->|$)~',
-					'$1$2$3',
+					'~^\\\\([A-Z_a-z\x80-\xFF][0-9A-Z_a-z\x80-\xFF]*)([:(\p{Z}]|->|$)~',
+					'$1$2',
 					$value,
 				);
 

--- a/lib/runner.php
+++ b/lib/runner.php
@@ -90,7 +90,7 @@ function parse_files( $files, $root ) {
 				$out['constants'][] = array(
 					'name'  => $constant->getShortName(),
 					'line'  => $constant->getLineNumber(),
-					'value' => $constant->getValue(),
+					'value' => export_expression( $constant->getNode()->value ),
 				);
 			}
 
@@ -184,6 +184,48 @@ function strip_global_namespace_prefixes( array $names ) {
 	}
 
 	return $names;
+}
+
+/**
+ * Export an expression without PHP-Parser's synthetic global namespace prefixes.
+ *
+ * @param null|\PhpParser\Node\Expr $expression Expression to export.
+ *
+ * @return null|string
+ */
+function export_expression( $expression ) {
+	if ( null === $expression ) {
+		return null;
+	}
+
+	static $printer = null;
+
+	if ( null === $printer ) {
+		$printer = new Pretty_Printer();
+	}
+
+	return $printer->prettyPrintExpr( $expression );
+}
+
+/**
+ * Remove synthetic global namespace prefixes from inline DocBlock references.
+ *
+ * @param string $text Formatted DocBlock text.
+ *
+ * @return string
+ */
+function strip_global_namespace_prefixes_from_inline_references( $text ) {
+	return preg_replace_callback(
+		'~{@(?:link|see)\s+([^}\s]+)~',
+		static function( $matches ) {
+			return str_replace(
+				$matches[1],
+				strip_global_namespace_prefix( $matches[1] ),
+				$matches[0]
+			);
+		},
+		$text
+	);
 }
 
 /**
@@ -514,8 +556,12 @@ function export_docblock( $element, array $inherited_setup_blueprints = array(),
 	}
 
 	$output = array(
-		'description'      => preg_replace( '/[\n\r]+/', ' ', $short_description ),
-		'long_description' => format_long_description( strip_docblock_code_snippet_fences( $raw_long_description, $fences ) ),
+		'description'      => strip_global_namespace_prefixes_from_inline_references(
+			preg_replace( '/[\n\r]+/', ' ', $short_description )
+		),
+		'long_description' => strip_global_namespace_prefixes_from_inline_references(
+			format_long_description( strip_docblock_code_snippet_fences( $raw_long_description, $fences ) )
+		),
 		'tags'             => array(),
 	);
 
@@ -535,19 +581,21 @@ function export_docblock( $element, array $inherited_setup_blueprints = array(),
 
 		$tag_data = array(
 			'name'    => $tag->getName(),
-			'content' => preg_replace( '/[\n\r]+/', ' ', format_description( $tag->getDescription() ) ),
+			'content' => strip_global_namespace_prefixes_from_inline_references(
+				preg_replace( '/[\n\r]+/', ' ', format_description( $tag->getDescription() ) )
+			),
 		);
 		if ( method_exists( $tag, 'getTypes' ) ) {
 			$tag_data['types'] = strip_global_namespace_prefixes( $tag->getTypes() );
 		}
 		if ( method_exists( $tag, 'getLink' ) ) {
-			$tag_data['link'] = $tag->getLink();
+			$tag_data['link'] = strip_global_namespace_prefix( $tag->getLink() );
 		}
 		if ( method_exists( $tag, 'getVariableName' ) ) {
 			$tag_data['variable'] = $tag->getVariableName();
 		}
 		if ( method_exists( $tag, 'getReference' ) ) {
-			$tag_data['refers'] = $tag->getReference();
+			$tag_data['refers'] = strip_global_namespace_prefix( $tag->getReference() );
 		}
 		if ( method_exists( $tag, 'getVersion' ) ) {
 			// Version string.
@@ -557,7 +605,9 @@ function export_docblock( $element, array $inherited_setup_blueprints = array(),
 			}
 			// Description string.
 			if ( method_exists( $tag, 'getDescription' ) ) {
-				$description = preg_replace( '/[\n\r]+/', ' ', format_description( $tag->getDescription() ) );
+				$description = strip_global_namespace_prefixes_from_inline_references(
+					preg_replace( '/[\n\r]+/', ' ', format_description( $tag->getDescription() ) )
+				);
 				if ( ! empty( $description ) ) {
 					$tag_data['description'] = $description;
 				}
@@ -705,7 +755,7 @@ function export_arguments( array $arguments ) {
 	foreach ( $arguments as $argument ) {
 		$output[] = array(
 			'name'    => $argument->getName(),
-			'default' => $argument->getDefault(),
+			'default' => export_expression( $argument->getNode()->default ),
 			'type'    => strip_global_namespace_prefix( $argument->getType() ),
 		);
 	}
@@ -728,7 +778,7 @@ function export_properties( array $properties, array $inherited_setup_blueprints
 			'name'        => $property->getName(),
 			'line'        => $property->getLineNumber(),
 			'end_line'    => $property->getNode()->getAttribute( 'endLine' ),
-			'default'     => $property->getDefault(),
+			'default'     => export_expression( $property->getNode()->default ),
 //			'final' => $property->isFinal(),
 			'static'      => $property->isStatic(),
 			'visibility'  => $property->getVisibility(),

--- a/tests/phpunit/tests/export/docblocks.inc
+++ b/tests/phpunit/tests/export/docblocks.inc
@@ -51,6 +51,11 @@ function test_func( $var, $num ) {
 function test_special_characters() {}
 
 /**
+ * \xC0 starts this description.
+ */
+function test_leading_escape_sequence() {}
+
+/**
  * This is a class docblock.
  *
  * This is the more wordy description: This is a comment with two *'s at the start,

--- a/tests/phpunit/tests/export/docblocks.inc
+++ b/tests/phpunit/tests/export/docblocks.inc
@@ -41,6 +41,16 @@ function test_func( $var, $num ) {
 }
 
 /**
+ * Tests special characters in documentation.
+ *
+ * ```php
+ * true === wp_is_valid_utf8( '✏' );
+ * false === wp_is_valid_utf8( "just \xC0 test" );
+ * ```
+ */
+function test_special_characters() {}
+
+/**
  * This is a class docblock.
  *
  * This is the more wordy description: This is a comment with two *'s at the start,

--- a/tests/phpunit/tests/export/docblocks.php
+++ b/tests/phpunit/tests/export/docblocks.php
@@ -244,6 +244,18 @@ class Export_Docblocks extends Export_UnitTestCase {
 	}
 
 	/**
+	 * Test that a leading escape sequence in documentation is preserved.
+	 */
+	public function test_leading_escape_sequence_is_preserved() {
+		$this->assertFunctionHasDocs(
+			'test_leading_escape_sequence',
+			array(
+				'description' => '\\xC0 starts this description.',
+			)
+		);
+	}
+
+	/**
 	 * Test that class docs are exported.
 	 */
 	public function test_class_docblocks() {

--- a/tests/phpunit/tests/export/docblocks.php
+++ b/tests/phpunit/tests/export/docblocks.php
@@ -231,6 +231,19 @@ class Export_Docblocks extends Export_UnitTestCase {
 	}
 
 	/**
+	 * Test that special characters in documentation are preserved.
+	 */
+	public function test_special_characters_are_preserved() {
+		$this->assertFunctionHasDocs(
+			'test_special_characters',
+			array(
+				'long_description' => '<pre><code class="language-php">true === wp_is_valid_utf8( \'✏\' );' . "\n"
+					. 'false === wp_is_valid_utf8( "just \\xC0 test" );</code></pre>',
+			)
+		);
+	}
+
+	/**
 	 * Test that class docs are exported.
 	 */
 	public function test_class_docblocks() {

--- a/tests/phpunit/tests/export/global-names.inc
+++ b/tests/phpunit/tests/export/global-names.inc
@@ -5,10 +5,30 @@ use \Global_Alias_Source as Global_Alias;
 /**
  * Documents a global type.
  *
+ * Calls {@see Global_Doc_Function()} while preserving \xC0 as documentation.
+ *
  * @param Global_Doc_Type $value Value.
  */
-function documented_global_type( \Global_Parameter $value ) {}
+function documented_global_type( \Global_Parameter $value, $enabled = true, $nothing = null, $mode = GLOBAL_MODE, $escape = '\xC0', $namespaced = \Vendor\GLOBAL_MODE ) {}
 
 class Global_Child extends \Global_Parent implements \Global_Interface {}
 
 \Global_Class::global_method();
+
+const GLOBAL_CONST = GLOBAL_VALUE;
+
+define( 'GLOBAL_DEFINED_CONST', global_default( GLOBAL_VALUE ) );
+define( 'NAMESPACED_DEFINED_CONST', \Vendor\global_default( \Vendor\GLOBAL_VALUE ) );
+
+class Global_Defaults {
+	public $enabled = false;
+	public $mode = GLOBAL_MODE;
+
+	public function create() {
+		return ( new \Global_Class() )->global_method();
+	}
+
+	public function create_namespaced() {
+		return ( new \Vendor\Global_Class() )->global_method();
+	}
+}

--- a/tests/phpunit/tests/export/global-names.inc
+++ b/tests/phpunit/tests/export/global-names.inc
@@ -1,0 +1,14 @@
+<?php
+
+use \Global_Alias_Source as Global_Alias;
+
+/**
+ * Documents a global type.
+ *
+ * @param Global_Doc_Type $value Value.
+ */
+function documented_global_type( \Global_Parameter $value ) {}
+
+class Global_Child extends \Global_Parent implements \Global_Interface {}
+
+\Global_Class::global_method();

--- a/tests/phpunit/tests/export/global-names.inc
+++ b/tests/phpunit/tests/export/global-names.inc
@@ -32,3 +32,17 @@ class Global_Defaults {
 		return ( new \Vendor\Global_Class() )->global_method();
 	}
 }
+
+/**
+ * Documents inline references.
+ *
+ * Calls {@see \Global_Doc_Function()} and {@see \Vendor\Thing::m()} in prose.
+ *
+ * Spells `{@see \Global_Inline::method()}` in an inline code span.
+ *
+ * ```php
+ * // Renders {@see \Global_Widget::render()}.
+ * $widget->render();
+ * ```
+ */
+function documented_inline_references() {}

--- a/tests/phpunit/tests/export/global-names.php
+++ b/tests/phpunit/tests/export/global-names.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * A test case for exporting global names.
+ */
+
+namespace WP_Parser\Tests;
+
+/**
+ * Test that synthetic global namespace prefixes are removed from metadata.
+ */
+class Export_Global_Names extends Export_UnitTestCase {
+
+	/**
+	 * Test function metadata.
+	 */
+	public function test_function_metadata() {
+		$function = $this->export_data['functions'][0];
+
+		$this->assertEquals(
+			array( 'Global_Alias' => 'Global_Alias_Source' ),
+			$function['aliases']
+		);
+		$this->assertEquals( 'Global_Parameter', $function['arguments'][0]['type'] );
+		$this->assertEquals(
+			array( 'Global_Doc_Type' ),
+			$function['doc']['tags'][0]['types']
+		);
+	}
+
+	/**
+	 * Test class metadata.
+	 */
+	public function test_class_metadata() {
+		$class = $this->export_data['classes'][0];
+
+		$this->assertEquals( 'Global_Parent', $class['extends'] );
+		$this->assertEquals( array( 'Global_Interface' ), $class['implements'] );
+	}
+
+	/**
+	 * Test method-use metadata.
+	 */
+	public function test_method_use_metadata() {
+		$this->assertFileUsesMethod(
+			array(
+				'name'     => 'global_method',
+				'line'     => 14,
+				'end_line' => 14,
+				'class'    => 'Global_Class',
+				'static'   => true,
+			)
+		);
+	}
+}

--- a/tests/phpunit/tests/export/global-names.php
+++ b/tests/phpunit/tests/export/global-names.php
@@ -42,6 +42,54 @@ class Export_Global_Names extends Export_UnitTestCase {
 	}
 
 	/**
+	 * Test that prefixes are removed from inline references in prose.
+	 */
+	public function test_prefixed_inline_reference_metadata() {
+		$function = $this->export_data['functions'][1];
+
+		$this->assertStringContainsString(
+			'{@see Global_Doc_Function()}',
+			$function['doc']['long_description']
+		);
+	}
+
+	/**
+	 * Test that namespaced inline references keep their prefix.
+	 */
+	public function test_namespaced_inline_reference_metadata() {
+		$function = $this->export_data['functions'][1];
+
+		$this->assertStringContainsString(
+			'{@see \\Vendor\\Thing::m()}',
+			$function['doc']['long_description']
+		);
+	}
+
+	/**
+	 * Test that inline references in code samples are preserved.
+	 */
+	public function test_code_sample_inline_reference_metadata() {
+		$function = $this->export_data['functions'][1];
+
+		$this->assertStringContainsString(
+			'// Renders {@see \\Global_Widget::render()}.',
+			$function['doc']['long_description']
+		);
+	}
+
+	/**
+	 * Test that inline references in inline code spans are preserved.
+	 */
+	public function test_inline_code_span_inline_reference_metadata() {
+		$function = $this->export_data['functions'][1];
+
+		$this->assertStringContainsString(
+			'<code>{@see \\Global_Inline::method()}</code>',
+			$function['doc']['long_description']
+		);
+	}
+
+	/**
 	 * Test class metadata.
 	 */
 	public function test_class_metadata() {

--- a/tests/phpunit/tests/export/global-names.php
+++ b/tests/phpunit/tests/export/global-names.php
@@ -22,6 +22,19 @@ class Export_Global_Names extends Export_UnitTestCase {
 			$function['aliases']
 		);
 		$this->assertEquals( 'Global_Parameter', $function['arguments'][0]['type'] );
+		$this->assertSame( 'true', $function['arguments'][1]['default'] );
+		$this->assertSame( 'null', $function['arguments'][2]['default'] );
+		$this->assertSame( 'GLOBAL_MODE', $function['arguments'][3]['default'] );
+		$this->assertSame( "'\\xC0'", $function['arguments'][4]['default'] );
+		$this->assertSame( '\\Vendor\\GLOBAL_MODE', $function['arguments'][5]['default'] );
+		$this->assertStringContainsString(
+			'{@see Global_Doc_Function()}',
+			$function['doc']['long_description']
+		);
+		$this->assertStringContainsString(
+			'\\xC0 as documentation',
+			$function['doc']['long_description']
+		);
 		$this->assertEquals(
 			array( 'Global_Doc_Type' ),
 			$function['doc']['tags'][0]['types']
@@ -39,14 +52,45 @@ class Export_Global_Names extends Export_UnitTestCase {
 	}
 
 	/**
+	 * Test expression metadata.
+	 */
+	public function test_expression_metadata() {
+		$this->assertSame( 'GLOBAL_VALUE', $this->export_data['constants'][0]['value'] );
+		$this->assertSame(
+			'global_default(GLOBAL_VALUE)',
+			$this->export_data['constants'][1]['value']
+		);
+		$this->assertSame(
+			'\\Vendor\\global_default(\\Vendor\\GLOBAL_VALUE)',
+			$this->export_data['constants'][2]['value']
+		);
+
+		$class = $this->export_data['classes'][1];
+		$this->assertSame( 'false', $class['properties'][0]['default'] );
+		$this->assertSame( 'GLOBAL_MODE', $class['properties'][1]['default'] );
+
+		$method = $class['methods'][0];
+		$this->assertSame(
+			'new Global_Class()',
+			$method['uses']['methods'][0]['class']
+		);
+
+		$method = $class['methods'][1];
+		$this->assertSame(
+			'new \\Vendor\\Global_Class()',
+			$method['uses']['methods'][0]['class']
+		);
+	}
+
+	/**
 	 * Test method-use metadata.
 	 */
 	public function test_method_use_metadata() {
 		$this->assertFileUsesMethod(
 			array(
 				'name'     => 'global_method',
-				'line'     => 14,
-				'end_line' => 14,
+				'line'     => 16,
+				'end_line' => 16,
 				'class'    => 'Global_Class',
 				'static'   => true,
 			)

--- a/tests/phpunit/tests/export/hooks.inc
+++ b/tests/phpunit/tests/export/hooks.inc
@@ -10,3 +10,9 @@ do_action( '\xC0 hook' );
 do_action( "\x09tab" );
 do_action( '\x09tab' );
 do_action( "\xC0 bad" );
+apply_filters( 'heredoc_filter', <<<EOT
+heredoc body
+EOT, 2 );
+apply_filters( 'nowdoc_filter', <<<'EOT'
+nowdoc $body
+EOT, 2 );

--- a/tests/phpunit/tests/export/hooks.inc
+++ b/tests/phpunit/tests/export/hooks.inc
@@ -6,3 +6,4 @@ do_action( $variable . '-action' );
 do_action( "another-{$variable}-action" );
 do_action( 'hook_' . $object->property . '_pre' );
 apply_filters( 'plain_filter', $variable, $filter_context );
+do_action( '\xC0 hook' );

--- a/tests/phpunit/tests/export/hooks.inc
+++ b/tests/phpunit/tests/export/hooks.inc
@@ -16,3 +16,5 @@ EOT, 2 );
 apply_filters( 'nowdoc_filter', <<<'EOT'
 nowdoc $body
 EOT, 2 );
+do_action( "it's" );
+do_action( 'it\'s' );

--- a/tests/phpunit/tests/export/hooks.inc
+++ b/tests/phpunit/tests/export/hooks.inc
@@ -9,3 +9,4 @@ apply_filters( 'plain_filter', $variable, $filter_context );
 do_action( '\xC0 hook' );
 do_action( "\x09tab" );
 do_action( '\x09tab' );
+do_action( "\xC0 bad" );

--- a/tests/phpunit/tests/export/hooks.inc
+++ b/tests/phpunit/tests/export/hooks.inc
@@ -7,3 +7,5 @@ do_action( "another-{$variable}-action" );
 do_action( 'hook_' . $object->property . '_pre' );
 apply_filters( 'plain_filter', $variable, $filter_context );
 do_action( '\xC0 hook' );
+do_action( "\x09tab" );
+do_action( '\x09tab' );

--- a/tests/phpunit/tests/export/hooks.php
+++ b/tests/phpunit/tests/export/hooks.php
@@ -96,6 +96,21 @@ class Export_Hooks extends Export_UnitTestCase {
 	}
 
 	/**
+	 * Test that hook names containing a quote character lose the quotes that
+	 * surround them in the source.
+	 */
+	public function test_hook_names_containing_quotes() {
+
+		$this->assertFileContainsHook(
+			array( 'name' => "it's", 'line' => 19 )
+		);
+
+		$this->assertFileContainsHook(
+			array( 'name' => "it\\'s", 'line' => 20 )
+		);
+	}
+
+	/**
 	 * Test that the exported data can be encoded as JSON.
 	 */
 	public function test_export_data_is_json_encodable() {

--- a/tests/phpunit/tests/export/hooks.php
+++ b/tests/phpunit/tests/export/hooks.php
@@ -70,6 +70,32 @@ class Export_Hooks extends Export_UnitTestCase {
 	}
 
 	/**
+	 * Test that heredoc and nowdoc arguments keep their delimiters.
+	 */
+	public function test_hook_arguments_keep_doc_string_delimiters() {
+
+		$this->assertFileContainsHook(
+			array(
+				'type' => 'filter',
+				'name' => 'heredoc_filter',
+				'line' => 13,
+				'arguments.0' => "<<<EOT\nheredoc body\nEOT",
+				'arguments.1' => '2',
+			)
+		);
+
+		$this->assertFileContainsHook(
+			array(
+				'type' => 'filter',
+				'name' => 'nowdoc_filter',
+				'line' => 16,
+				'arguments.0' => "<<<'EOT'\nnowdoc \$body\nEOT",
+				'arguments.1' => '2',
+			)
+		);
+	}
+
+	/**
 	 * Test that the exported data can be encoded as JSON.
 	 */
 	public function test_export_data_is_json_encodable() {

--- a/tests/phpunit/tests/export/hooks.php
+++ b/tests/phpunit/tests/export/hooks.php
@@ -51,11 +51,32 @@ class Export_Hooks extends Export_UnitTestCase {
 		);
 
 		$this->assertFileContainsHook(
-			array( 'name' => "\ttab", 'line' => 10 )
+			array( 'name' => '\\x09tab', 'line' => 10 )
 		);
 
 		$this->assertFileContainsHook(
 			array( 'name' => '\\x09tab', 'line' => 11 )
+		);
+	}
+
+	/**
+	 * Test that hook names keep escapes that are invalid UTF-8 once interpreted.
+	 */
+	public function test_hook_names_keep_invalid_utf8_escapes() {
+
+		$this->assertFileContainsHook(
+			array( 'name' => '\\xC0 bad', 'line' => 12 )
+		);
+	}
+
+	/**
+	 * Test that the exported data can be encoded as JSON.
+	 */
+	public function test_export_data_is_json_encodable() {
+
+		$this->assertNotFalse(
+			json_encode( $this->export_data, JSON_PRETTY_PRINT ),
+			json_last_error_msg()
 		);
 	}
 }

--- a/tests/phpunit/tests/export/hooks.php
+++ b/tests/phpunit/tests/export/hooks.php
@@ -49,5 +49,13 @@ class Export_Hooks extends Export_UnitTestCase {
 		$this->assertFileContainsHook(
 			array( 'name' => '\\xC0 hook', 'line' => 9 )
 		);
+
+		$this->assertFileContainsHook(
+			array( 'name' => "\ttab", 'line' => 10 )
+		);
+
+		$this->assertFileContainsHook(
+			array( 'name' => '\\x09tab', 'line' => 11 )
+		);
 	}
 }

--- a/tests/phpunit/tests/export/hooks.php
+++ b/tests/phpunit/tests/export/hooks.php
@@ -45,5 +45,9 @@ class Export_Hooks extends Export_UnitTestCase {
 				'arguments.1' => '$filter_context'
 			)
 		);
+
+		$this->assertFileContainsHook(
+			array( 'name' => '\\xC0 hook', 'line' => 9 )
+		);
 	}
 }

--- a/tests/phpunit/tests/export/snippet-verbatim.inc
+++ b/tests/phpunit/tests/export/snippet-verbatim.inc
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * File summary.
+ *
+ * ```setup-blueprint global-setup
+ * {
+ *   "steps": [
+ *     {
+ *       "step": "writeFile",
+ *       "path": "/wordpress/wp-content/mu-plugins/global-setup.php",
+ *       "data": "<?php\n\\Docs_Global_Registry::register( '\\Docs_Global' );\n"
+ *     }
+ *   ]
+ * }
+ * ```
+ *
+ * @since 1.0.0
+ */
+
+/**
+ * This is a function docblock.
+ *
+ * ```php interactive setup-blueprint=global-setup
+ * <?php
+ * require '/wordpress/wp-load.php';
+ * echo \Docs_Global::greet();
+ * ```
+ *
+ * ```expected-output
+ * Hello from \Docs_Global
+ * ```
+ *
+ * @since 1.0.0
+ */
+function snippet_verbatim_func() {}

--- a/tests/phpunit/tests/export/snippet-verbatim.php
+++ b/tests/phpunit/tests/export/snippet-verbatim.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * A test case for exporting snippet source verbatim.
+ */
+
+namespace WP_Parser\Tests;
+
+/**
+ * Test that snippet and Blueprint source is exported exactly as authored.
+ *
+ * Global-name prefix stripping applies to documentation prose and metadata,
+ * never to executable snippet source or Blueprint definitions.
+ */
+class Export_Snippet_Verbatim extends Export_UnitTestCase {
+
+	/**
+	 * Test that snippet code keeps fully qualified global names.
+	 */
+	public function test_snippet_code_is_verbatim() {
+
+		$this->assertEquals(
+			array(
+				array(
+					'type' => 'php-code-snippet',
+					'code' => "<?php\nrequire '/wordpress/wp-load.php';\necho \\Docs_Global::greet();",
+					'expected_output' => 'Hello from \\Docs_Global',
+					'blueprint' => 'global-setup',
+				),
+			),
+			$this->export_data['functions'][0]['doc']['code_snippets']
+		);
+	}
+
+	/**
+	 * Test that Blueprint definitions keep fully qualified global names.
+	 */
+	public function test_setup_blueprint_is_verbatim() {
+
+		$this->assertEquals(
+			array(
+				'global-setup' => array(
+					'steps' => array(
+						array(
+							'step' => 'writeFile',
+							'path' => '/wordpress/wp-content/mu-plugins/global-setup.php',
+							'data' => "<?php\n\\Docs_Global_Registry::register( '\\Docs_Global' );\n",
+						),
+					),
+				),
+			),
+			$this->export_data['functions'][0]['doc']['setup_blueprints']
+		);
+	}
+}

--- a/tests/phpunit/tests/export/uses/class-mapping.inc
+++ b/tests/phpunit/tests/export/uses/class-mapping.inc
@@ -1,0 +1,5 @@
+<?php
+
+function show_help() {
+	get_current_screen()->add_help_tab( array() );
+}

--- a/tests/phpunit/tests/export/uses/class-mapping.php
+++ b/tests/phpunit/tests/export/uses/class-mapping.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * A test case for exporting the mapped class of a method call.
+ */
+
+namespace WP_Parser\Tests;
+
+/**
+ * Test that calls on known factory functions are exported with the class they return.
+ */
+class Export_Mapped_Class_Use extends Export_UnitTestCase {
+
+	/**
+	 * Test that a method called on a mapped function is exported with its class.
+	 */
+	public function test_mapped_function_receiver() {
+
+		$this->assertFunctionUsesMethod(
+			'show_help'
+			, array(
+				'name'     => 'add_help_tab',
+				'line'     => 4,
+				'end_line' => 4,
+				'class'    => 'WP_Screen',
+				'static'   => false,
+			)
+		);
+	}
+}


### PR DESCRIPTION
Settles a policy question left open during the #262 rebase: after the targeted redesign of global-name prefix stripping, `doc.code_snippets[].code` / `expected_output` and `setup_blueprints` receive no stripping at all — master's blanket `array_walk_recursive` used to touch them. That is the correct behavior — snippets and Blueprint definitions are executable, verbatim source, not prose — but nobody had stated it or pinned it.

This adds a fixture whose snippet code, expected output, and Blueprint `writeFile` data all contain `\`-qualified global names, and asserts they export exactly as authored.

The test passes on `fix-254`. The same test run against master fails: the blanket walk rewrites the snippet to `echo Docs_Global::greet();` and the expected output to `Hello from Docs_Global` — demonstrating that the pin captures a real difference in #262's behavior, not a tautology. (Master happens to leave this particular Blueprint data alone because its backslashes follow a newline and a quote rather than a space — which only underlines how incidental the old stripping was.)

Targets `fix-254` to land with #262.

🤖 Generated with [Claude Code](https://claude.com/claude-code)