### PR TITLE
Preserve backslashes in imported tag, argument, alias, and class meta

### DIFF
--- a/lib/class-importer.php
+++ b/lib/class-importer.php
@@ -433,9 +433,12 @@ class Importer implements LoggerAwareInterface {
 		// Set class-specific meta
 		update_post_meta( $class_id, '_wp-parser_final', (string) $data['final'] );
 		update_post_meta( $class_id, '_wp-parser_abstract', (string) $data['abstract'] );
-		update_post_meta( $class_id, '_wp-parser_extends', $data['extends'] );
-		update_post_meta( $class_id, '_wp-parser_implements', $data['implements'] );
-		update_post_meta( $class_id, '_wp-parser_properties', $data['properties'] );
+		// Metadata APIs unslash their input. map_deep() reaches every nested
+		// string, preserving the namespace separators in class relatives and
+		// property types.
+		update_post_meta( $class_id, '_wp-parser_extends', map_deep( $data['extends'], 'wp_slash' ) );
+		update_post_meta( $class_id, '_wp-parser_implements', map_deep( $data['implements'], 'wp_slash' ) );
+		update_post_meta( $class_id, '_wp-parser_properties', map_deep( $data['properties'], 'wp_slash' ) );
 
 		// Now add the methods
 		foreach ( $data['methods'] as $method ) {
@@ -743,13 +746,16 @@ class Importer implements LoggerAwareInterface {
 			$data['doc']['tags']['deprecated'] = $this->file_meta['deprecated'];
 		}
 
+		// Metadata APIs unslash their input. map_deep() reaches every nested
+		// string, preserving the namespace separators in argument and alias
+		// types.
 		if ( $post_data['post_type'] !== $this->post_type_class ) {
-			$anything_updated[] = update_post_meta( $post_id, '_wp-parser_args', $data['arguments'] );
+			$anything_updated[] = update_post_meta( $post_id, '_wp-parser_args', map_deep( $data['arguments'], 'wp_slash' ) );
 		}
 
 		// If the post type is using namespace aliases, record them.
 		if ( ! empty( $data['aliases'] ) ) {
-			$anything_updated[] = update_post_meta( $post_id, '_wp_parser_aliases', (array) $data['aliases'] );
+			$anything_updated[] = update_post_meta( $post_id, '_wp_parser_aliases', map_deep( (array) $data['aliases'], 'wp_slash' ) );
 		}
 
 		// Recored the namespace if there is one.
@@ -759,7 +765,11 @@ class Importer implements LoggerAwareInterface {
 
 		$anything_updated[] = update_post_meta( $post_id, '_wp-parser_line_num', (string) $data['line'] );
 		$anything_updated[] = update_post_meta( $post_id, '_wp-parser_end_line_num', (string) $data['end_line'] );
-		$anything_updated[] = update_post_meta( $post_id, '_wp-parser_tags', $data['doc']['tags'] );
+
+		// Metadata APIs unslash their input. map_deep() reaches every nested
+		// string, preserving the namespace separators in tag types and
+		// references such as `@param \Foo\Bar` and `@see \Foo\Bar`.
+		$anything_updated[] = update_post_meta( $post_id, '_wp-parser_tags', map_deep( $data['doc']['tags'], 'wp_slash' ) );
 
 		// Metadata APIs unslash their input. map_deep() reaches retained JSON
 		// objects as well as arrays, preserving backslashes in PHP and Blueprint

--- a/tests/phpunit/tests/import/file.php
+++ b/tests/phpunit/tests/import/file.php
@@ -213,4 +213,165 @@ class File_Import_Test extends Import_UnitTestCase {
 		$this->assertEquals( $snippets, get_post_meta( $post->ID, '_wp-parser_code_snippets', true ) );
 		$this->assertEquals( $setup_blueprints, get_post_meta( $post->ID, '_wp-parser_setup_blueprints', true ) );
 	}
+
+	/**
+	 * Test that WordPress metadata slashing does not alter DocBlock tags.
+	 */
+	public function test_function_tag_metadata_preserves_backslashes() {
+
+		$posts = get_posts(
+			array( 'post_type' => $this->importer->post_type_function )
+		);
+		$post  = $posts[0];
+
+		$function_data = $this->export_data['functions'][0];
+		$tags          = array(
+			array(
+				'name'    => 'see',
+				'content' => '',
+				'refers'  => '\Docs\Example::method()',
+			),
+			array(
+				'name'     => 'param',
+				'content'  => 'A namespaced parameter.',
+				'types'    => array( '\Foo', '\Foo\Bar', 'Vendor\Foo' ),
+				'variable' => '$var',
+			),
+		);
+
+		$function_data['doc']['tags'] = $tags;
+
+		$this->importer->import_function( $function_data );
+
+		$this->assertEquals( $tags, get_post_meta( $post->ID, '_wp-parser_tags', true ) );
+	}
+
+	/**
+	 * Test that WordPress metadata slashing does not alter argument metadata.
+	 */
+	public function test_function_argument_metadata_preserves_backslashes() {
+
+		$posts = get_posts(
+			array( 'post_type' => $this->importer->post_type_function )
+		);
+		$post  = $posts[0];
+
+		$function_data = $this->export_data['functions'][0];
+		$arguments     = array(
+			array(
+				'name'    => '$leading',
+				'default' => null,
+				'type'    => '\Foo',
+			),
+			array(
+				'name'    => '$qualified',
+				'default' => null,
+				'type'    => '\Foo\Bar',
+			),
+			array(
+				'name'    => '$relative',
+				'default' => '\Vendor\Foo::DEFAULT_VALUE',
+				'type'    => 'Vendor\Foo',
+			),
+		);
+
+		$function_data['arguments'] = $arguments;
+
+		$this->importer->import_function( $function_data );
+
+		$this->assertEquals( $arguments, get_post_meta( $post->ID, '_wp-parser_args', true ) );
+	}
+
+	/**
+	 * Test that WordPress metadata slashing does not alter namespace aliases.
+	 */
+	public function test_function_alias_metadata_preserves_backslashes() {
+
+		$posts = get_posts(
+			array( 'post_type' => $this->importer->post_type_function )
+		);
+		$post  = $posts[0];
+
+		$function_data = $this->export_data['functions'][0];
+		$aliases       = array(
+			'Leading'   => '\Foo',
+			'Qualified' => '\Foo\Bar',
+			'Relative'  => 'Vendor\Foo',
+		);
+
+		$function_data['aliases'] = $aliases;
+
+		$this->importer->import_function( $function_data );
+
+		$this->assertEquals( $aliases, get_post_meta( $post->ID, '_wp_parser_aliases', true ) );
+	}
+
+	/**
+	 * Test that WordPress metadata slashing does not alter class metadata.
+	 */
+	public function test_class_metadata_preserves_backslashes() {
+
+		$properties = array(
+			array(
+				'name'       => '$example',
+				'line'       => 12,
+				'end_line'   => 12,
+				'default'    => '\Vendor\Foo::DEFAULT_VALUE',
+				'static'     => false,
+				'visibility' => 'public',
+				'doc'        => array(
+					'description'      => '',
+					'long_description' => '',
+					'tags'             => array(
+						array(
+							'name'     => 'var',
+							'content'  => 'A namespaced property.',
+							'types'    => array( '\Foo', '\Foo\Bar', 'Vendor\Foo' ),
+							'variable' => '',
+						),
+					),
+				),
+			),
+		);
+
+		$class_data = array(
+			'name'       => 'Slashing_Example',
+			'namespace'  => 'Vendor\Docs',
+			'line'       => 10,
+			'end_line'   => 14,
+			'final'      => false,
+			'abstract'   => false,
+			'extends'    => '\Foo\Bar',
+			'implements' => array( '\Foo', 'Vendor\Foo' ),
+			'properties' => $properties,
+			'methods'    => array(),
+			'doc'        => array(
+				'description'      => 'A class with namespaced relatives.',
+				'long_description' => '',
+				'tags'             => array(),
+			),
+		);
+
+		$file_data              = $this->export_data;
+		$file_data['functions'] = array();
+		$file_data['classes']   = array( $class_data );
+		$file_data['hooks']     = array();
+
+		$this->importer->import_file( $file_data, true );
+
+		$posts = get_posts(
+			array( 'post_type' => $this->importer->post_type_class )
+		);
+
+		$this->assertCount( 1, $posts );
+
+		$post = $posts[0];
+
+		$this->assertEquals( '\Foo\Bar', get_post_meta( $post->ID, '_wp-parser_extends', true ) );
+		$this->assertEquals( array( '\Foo', 'Vendor\Foo' ), get_post_meta( $post->ID, '_wp-parser_implements', true ) );
+		$this->assertEquals( $properties, get_post_meta( $post->ID, '_wp-parser_properties', true ) );
+
+		// The namespace is already compensated for; it must not be slashed twice.
+		$this->assertEquals( 'Vendor\Docs', get_post_meta( $post->ID, '_wp_parser_namespace', true ) );
+	}
 }


### PR DESCRIPTION
## ⚠️ Gated: do not merge before the wporg-developer theme is fixed

**Merging this is blocked on theme-side fixes in `wporg-developer`.** Today the
importer's unslash bug *accidentally strips* backslashes out of tag/arg/class
meta, and that accidental stripping is what currently masks several
backslash-intolerant spots in the theme. Fixing the importer alone would start
delivering backslashes to code that mishandles them, turning a silent data
corruption into a visible regression.

The theme items that must land first or simultaneously (items B1/B2/B4 in the
internal follow-ups handoff):

- **B1** — `inc/template-tags.php` calls `DevHub_Formatting::link_internal_element()`
  directly for the deprecation notice and drops the whole "Use %s instead."
  sentence when nothing links; a backslashed `@see \Some_Class` either vanishes
  or emits a wrong-post-type URL.
- **B2** — `get_used_by()` compares `_wp-parser_extends` `meta_value` against
  `post_name` with raw SQL equality, so any `\` in the stored `extends` breaks a
  parent class's "Used by" list. This is the hard constraint: **`extends` must
  stay stripped until B2 is fixed.**
- **B4** — the bare-class branch of `link_internal_element()` in
  `inc/formatting.php` uses an anchored regex plus an exact-match exception
  list, so `\WP_Query` / `\wpdb` do not link there.

## The bug

`update_post_meta()` runs its value through `wp_unslash()` →
`stripslashes_deep()`, so backslashes are eaten on write. The importer already
compensates for two things and nothing else:

- `_wp_parser_namespace` via `addslashes()`
- `_wp-parser_code_snippets` / `_wp-parser_setup_blueprints` via
  `map_deep( $value, 'wp_slash' )` (added with #258, with an explanatory comment
  and a pinning test)

Everything else is corrupted live, today, for any namespaced value:

| input | stored |
| --- | --- |
| `\Foo` | `Foo` |
| `\Foo\Bar` | `FooBar` |
| `Vendor\Foo` | `VendorFoo` |

So a `@param \Foo\Bar $x` is stored as `FooBar`.

## The fix

Apply the same `map_deep( $value, 'wp_slash' )` treatment, with a comment in the
same style, to the remaining fields:

| meta key | site |
| --- | --- |
| `_wp-parser_extends` | `Importer::import_class()` |
| `_wp-parser_implements` | `Importer::import_class()` |
| `_wp-parser_properties` | `Importer::import_class()` |
| `_wp-parser_args` | `Importer::import_item()` |
| `_wp_parser_aliases` | `Importer::import_item()` |
| `_wp-parser_tags` | `Importer::import_item()` |

`_wp_parser_namespace` is deliberately **untouched** — it is already compensated
with `addslashes()`, and slashing it again would double the separators. A new
assertion pins that it still round-trips as `Vendor\Docs`.

This is importer-side only; the exporter is not touched, so a corpus diff should
show 0 hunks.

## TDD

- `Add failing tests for backslash loss in imported meta` — RED
- `Slash imported tag, argument, alias, and class meta` — GREEN

The tests follow the existing pinning-test pattern
(`File_Import_Test::test_function_snippet_metadata_preserves_backslashes`) and
cover all three shapes — single leading backslash (`\Foo`), interior separators
(`\Foo\Bar`), and no-leading-slash namespaced (`Vendor\Foo`) — across tags
(`refers` and `param` types), argument types and defaults, aliases, `extends`,
`implements`, and property types.

RED (before the fix), showing exactly the corruption described above:

```
1) WP_Parser\Tests\File_Import_Test::test_function_tag_metadata_preserves_backslashes
-            0 => '\Foo'
-            1 => '\Foo\Bar'
-            2 => 'Vendor\Foo'
+            0 => 'Foo'
+            1 => 'FooBar'
+            2 => 'VendorFoo'

2) WP_Parser\Tests\File_Import_Test::test_function_argument_metadata_preserves_backslashes
-        'type' => '\Foo'
+        'type' => 'Foo'
...
3) WP_Parser\Tests\File_Import_Test::test_function_alias_metadata_preserves_backslashes
-    'Leading' => '\Foo'
+    'Leading' => 'Foo'
...
4) WP_Parser\Tests\File_Import_Test::test_class_metadata_preserves_backslashes
-'\Foo\Bar'
+'FooBar'

FAILURES!
Tests: 153, Assertions: 403, Failures: 4.
```

GREEN (after the fix), full suite:

```
OK (153 tests, 406 assertions)
```

## Open question — the second strip at display time

`lib/class-plugin.php:238` runs `stripslashes_deep` **again** at display time, as
the last filter in the `sanitize_argument()` chain used by `make_args_safe()`.
Whether that second strip should survive is undecided, and this PR deliberately
does not change it. Worth settling together with the theme work: with the
importer fixed, that filter is now the only remaining place that silently eats
backslashes out of argument data on the way to the template.

## Deviation from the reference implementation

An earlier local draft of this change used bare `wp_slash()` rather than
`map_deep( $value, 'wp_slash' )`, and also rewrote `_wp_parser_namespace` from
`addslashes()` to `wp_slash()`. This PR uses `map_deep()` for consistency with
the adjacent snippet/Blueprint code (it also reaches object properties, not just
array members, should any of these values ever carry decoded JSON objects), and
leaves `_wp_parser_namespace` alone. That earlier draft was also mixed with
unrelated type-rendering work; this PR contains only the meta-slashing concern.

## Not included

The `--env-cwd` hardcoding in `package.json` breaks `npm run test:phpunit` from
any worktree not literally named `phpdoc-parser`. That is fixed separately in
#276 and is deliberately not part of this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
