### PR TITLE
Harden GitHub Actions against zizmor findings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,16 +4,22 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     target-branch: master
 
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     target-branch: master
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     target-branch: master

--- a/.github/workflows/corpus-diff.yml
+++ b/.github/workflows/corpus-diff.yml
@@ -65,8 +65,7 @@ jobs:
           echo "WP_CORPUS_TAG=${WP_CORPUS_TAG}" >> "${GITHUB_ENV}"
 
       - name: Set up PHP
-        # zizmor: ignore[ref-version-mismatch] upstream omits the v prefix
-        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: "8.4"
           coverage: none

--- a/.github/workflows/corpus-diff.yml
+++ b/.github/workflows/corpus-diff.yml
@@ -33,14 +33,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-  pull-requests: write
+permissions: {}
 
 jobs:
   corpus-diff:
     name: WordPress corpus regeneration diff
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     env:
       CORPUS_PIN_FILE: .github/corpus-version
@@ -48,9 +48,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Read corpus pin
         run: |
@@ -64,7 +65,8 @@ jobs:
           echo "WP_CORPUS_TAG=${WP_CORPUS_TAG}" >> "${GITHUB_ENV}"
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+        # zizmor: ignore[ref-version-mismatch] upstream omits the v prefix
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
         with:
           php-version: "8.4"
           coverage: none
@@ -73,7 +75,7 @@ jobs:
       # step changes what it keeps.
       - name: Cache corpus
         id: cache-corpus
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: corpus
           key: wp-corpus-${{ env.WP_CORPUS_TAG }}-php-all
@@ -105,7 +107,9 @@ jobs:
       # now against base plus exactly this PR, with no hunks from other work
       # that landed since the branch point.
       - name: Check out base
-        run: git worktree add base "$(git merge-base "origin/${{ github.base_ref }}" HEAD)"
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: git worktree add base "$(git merge-base -- "origin/${BASE_REF}" HEAD)"
 
       - name: Install Composer dependencies (head)
         run: composer install --no-interaction --no-security-blocking
@@ -136,7 +140,7 @@ jobs:
       - name: Upload diff
         id: upload
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: corpus.diff
           path: corpus.diff
@@ -151,10 +155,31 @@ jobs:
           BASE_SHA="$(git -C base rev-parse HEAD)" tools/corpus-diff-comment.sh corpus.diff > comment.md
           tail -n +2 comment.md >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Upload rendered report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: corpus-diff-comment
+          path: comment.md
+          if-no-files-found: ignore
+
+  comment:
+    name: Publish corpus diff report
+    needs: corpus-diff
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # Create or update the corpus diff comment.
+
+    steps:
+      - name: Download rendered report
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: corpus-diff-comment
+
       # Create the comment on the first run and update it on every later one,
       # so the PR carries one report that reflects the latest push.
       - name: Comment on the pull request
-        if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}

--- a/.github/workflows/corpus-pin-update.yml
+++ b/.github/workflows/corpus-pin-update.yml
@@ -16,6 +16,8 @@ on:
     - cron: "17 3 * * 0"
   workflow_dispatch:
 
+permissions: {}
+
 concurrency:
   group: corpus-pin-update
   cancel-in-progress: false
@@ -28,8 +30,8 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write # Push the update branch.
+      pull-requests: write # Open the update pull request.
 
     env:
       # Keep the mutable pin outside `.github/workflows`: GITHUB_TOKEN cannot
@@ -44,8 +46,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # The push below uses the token saved by checkout.
-          persist-credentials: true
+          persist-credentials: false
 
       - name: Resolve the latest WordPress stable
         id: resolve
@@ -148,6 +149,7 @@ jobs:
           git commit -m "${title}"
           # No PR exists at this point. Reusing the branch repairs a run that
           # pushed but failed before opening its PR.
+          gh auth setup-git --hostname github.com --force
           git push --force origin "HEAD:refs/heads/${branch}"
 
           if ! url="$(gh pr create --repo "${GITHUB_REPOSITORY}" --base "${BASE_BRANCH}" --head "${branch}" --title "${title}" --body-file pr-body.md 2>&1)"; then

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -33,8 +33,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up PHP
-        # zizmor: ignore[ref-version-mismatch] upstream omits the v prefix
-        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: ${{ matrix.php-version }}
           coverage: none

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -5,8 +5,16 @@ on:
   push:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   test-php:
+    name: PHP ${{ matrix.php-version }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -20,10 +28,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+        # zizmor: ignore[ref-version-mismatch] upstream omits the v prefix
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
         with:
           php-version: ${{ matrix.php-version }}
           coverage: none


### PR DESCRIPTION
## Summary

- pin every GitHub Action to an immutable commit with its exact upstream version annotation and add seven-day Dependabot cooldowns
- remove inline shell template expansion and unnecessary persisted checkout credentials
- apply least-privilege token permissions, isolating PR comment publication from corpus analysis
- add unit-test concurrency limits and a descriptive matrix job name

## Validation

- zizmor 1.29.0 strict auditor, offline: no findings
- zizmor 1.29.0 strict auditor, online: no findings
- all workflow and Dependabot YAML parsed successfully with Ruby Psych
- bash syntax check for tools/corpus-diff-comment.sh
- git diff --check