### PR TITLE
Corpus diff follow-ups: failure reporting, renderer fixes, README sync

### DIFF
--- a/.github/workflows/corpus-diff.yml
+++ b/.github/workflows/corpus-diff.yml
@@ -145,13 +145,22 @@ jobs:
           archive: false
           if-no-files-found: ignore
 
+      # Render on failure too: the comment is updated in place, so skipping
+      # this step would leave the previous push's report standing as current.
       - name: Render report
+        if: ${{ !cancelled() }}
         env:
+          JOB_STATUS: ${{ job.status }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           ARTIFACT_URL: ${{ steps.upload.outputs.artifact-url }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          BASE_SHA="$(git -C base rev-parse HEAD)" tools/corpus-diff-comment.sh corpus.diff > comment.md
+          if [ "${JOB_STATUS}" = "success" ]; then
+            BASE_SHA="$(git -C base rev-parse HEAD)" tools/corpus-diff-comment.sh corpus.diff > comment.md
+          else
+            printf '<!-- corpus-diff -->\n### Corpus diff\n\n**Run failed** at `%s`; no diff was produced for this push. See the [run log](%s).\n' \
+              "${HEAD_SHA:0:7}" "${RUN_URL}" > comment.md
+          fi
           tail -n +2 comment.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload rendered report
@@ -165,7 +174,7 @@ jobs:
   comment:
     name: Publish corpus diff report
     needs: corpus-diff
-    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
+    if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write # Create or update the corpus diff comment.
@@ -185,7 +194,7 @@ jobs:
           PR: ${{ github.event.pull_request.number }}
         run: |
           ids=$(gh api "repos/${REPO}/issues/${PR}/comments" --paginate \
-            --jq '.[] | select(.body | startswith("<!-- corpus-diff -->")) | .id')
+            --jq '.[] | select(.user.login == "github-actions[bot]") | select(.body | startswith("<!-- corpus-diff -->")) | .id')
           id=${ids%%$'\n'*}
           if [ -n "$id" ]; then
             gh api --silent -X PATCH "repos/${REPO}/issues/comments/${id}" -F body=@comment.md

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,11 @@ vendor
 coverage
 node_modules
 .phpunit.result.cache
+# Local corpus-diff runs; see "Corpus diff" in the README.
+/base
+/corpus
+/WordPress-*
+/wordpress.zip
+/base.json
+/head.json
+/corpus.diff

--- a/README.md
+++ b/README.md
@@ -55,18 +55,20 @@ wp parser create /path/to/source/code --user=<id|login>
 
 Unit tests do not cover every shape of real-world documentation, so changes to the parser are also checked against a corpus of WordPress core source. The same corpus is parsed with the parser at two refs, the base branch and the pull request merged into it, and the two JSON exports are diffed. Everything in that diff is a behavior change the pull request makes: every hunk must be either intended and explained, or it is a regression.
 
-`.github/workflows/corpus-diff.yml` runs this on every pull request. The corpus is the PHP of a whole WordPress release at a pinned tag (`WP_CORPUS_TAG` in the workflow): wp-admin, wp-includes, the root files, and the bundled themes and plugins. Pinning keeps diffs reproducible. The job is non-blocking: it uploads the diff as a `corpus.diff` artifact, reports it in the job summary, and posts one comment on the pull request, updated on every push, with the hunk and line counts and the diff itself when it fits in a comment (`tools/corpus-diff-comment.sh` renders it). Pull requests from forks and from Dependabot run with a read-only token, so they get the summary and the artifact only. The head checkout's `tools/export-corpus.php` drives both sides, so tooling changes never masquerade as parser changes. The exports are diffed as emitted: both sides share the corpus, the PHP binary, and the exporter, so the output is already deterministic. `prep-diff.php` is for comparing exports from different environments; its line-number and namespace-prefix erasure and its collection sorting would hide or scatter real changes here.
+`.github/workflows/corpus-diff.yml` runs this on every pull request. The corpus is the PHP of a whole WordPress release at a pinned tag (`.github/corpus-version`): wp-admin, wp-includes, the root files, and the bundled themes and plugins. Pinning keeps diffs reproducible. The job is non-blocking: it uploads the diff as a `corpus.diff` artifact, reports it in the job summary, and posts one comment on the pull request, updated on every push, with the hunk and line counts and the diff itself when it fits in a comment (`tools/corpus-diff-comment.sh` renders it). Pull requests from forks and from Dependabot run with a read-only token, so they get the summary and the artifact only. The head checkout's `tools/export-corpus.php` drives both sides, so tooling changes never masquerade as parser changes. The exports are diffed as emitted: both sides share the corpus, the PHP binary, and the exporter, so the output is already deterministic. `prep-diff.php` is for comparing exports from different environments; its line-number and namespace-prefix erasure and its collection sorting would hide or scatter real changes here.
 
 To run it locally, get the pinned corpus:
 
 ```bash
-curl -sSfL -o wordpress.zip https://github.com/WordPress/WordPress/archive/refs/tags/7.0.4.zip
+tag="$(cat .github/corpus-version)"
+curl -sSfL -o wordpress.zip "https://github.com/WordPress/WordPress/archive/refs/tags/${tag}.zip"
 unzip -q wordpress.zip
 ```
 
-Check out the other side of the comparison and install its dependencies. The exporter runs under plain PHP — it does not load WordPress — but it needs a Composer autoloader in each parser root:
+Check out the other side of the comparison and install its dependencies. The exporter runs under plain PHP, without loading WordPress, but it needs a Composer autoloader in each parser root:
 
 ```bash
+git fetch origin
 git worktree add base "$(git merge-base origin/master HEAD)"
 composer --working-dir=base install
 composer install
@@ -78,9 +80,16 @@ Export both sides over the same corpus and diff. `export-corpus.php` takes the p
 
 ```bash
 export LC_ALL=C
-php -d memory_limit=4G tools/export-corpus.php base WordPress-7.0.4 > base.json
-php -d memory_limit=4G tools/export-corpus.php . WordPress-7.0.4 > head.json
+php -d memory_limit=4G tools/export-corpus.php base "WordPress-${tag}" > base.json
+php -d memory_limit=4G tools/export-corpus.php . "WordPress-${tag}" > head.json
 diff -u base.json head.json > corpus.diff
 ```
 
 An empty `corpus.diff` means the change has no effect on parser output.
+
+Clean up afterwards:
+
+```bash
+git worktree remove base
+rm -rf wordpress.zip "WordPress-${tag}" base.json head.json corpus.diff
+```

--- a/tools/corpus-diff-comment.sh
+++ b/tools/corpus-diff-comment.sh
@@ -9,8 +9,9 @@
 #
 # Optional: ARTIFACT_URL (download link for corpus.diff), RUN_URL (fallback
 # link), MAX_BYTES (largest body to emit; GitHub rejects comments over 65536
-# characters, default 60000). A diff that does not fit is cut to the leading
-# whole hunks that do, and the comment says so.
+# characters, default 60000). A diff that does not fit is cut to the whole
+# hunks, in order, that do. A hunk larger than the remaining budget is
+# skipped, not final: one oversized hunk must not hide the hunks after it.
 #
 # The first line is an HTML comment that marks the output as this tool's, so
 # the workflow can find and update its own comment instead of adding one per
@@ -25,9 +26,15 @@ diff_file=$1
 max_bytes=${MAX_BYTES:-60000}
 link=${ARTIFACT_URL:-${RUN_URL:-}}
 
+# A missing diff is a broken pipeline, not a clean one.
+if [ ! -e "$diff_file" ]; then
+	echo "corpus-diff-comment.sh: ${diff_file}: no such file" >&2
+	exit 1
+fi
+
 marker='<!-- corpus-diff -->'
 heading='### Corpus diff'
-compared="WordPress ${WP_CORPUS_TAG}, parser at \`${BASE_SHA:0:7}\` (base) vs \`${HEAD_SHA:0:7}\` (this PR merged)"
+compared="WordPress ${WP_CORPUS_TAG}, parser at \`${BASE_SHA:0:7}\` (base) vs \`${HEAD_SHA:0:7}\` (PR head, merged into base)"
 
 if [ ! -s "$diff_file" ]; then
 	printf '%s\n%s\n\n**0 hunks.** No behavior change over %s.\n' "$marker" "$heading" "$compared"
@@ -35,8 +42,10 @@ if [ ! -s "$diff_file" ]; then
 fi
 
 hunks=$(grep -c '^@@' "$diff_file" || true)
-added=$(grep -c '^+[^+]' "$diff_file" || true)
-removed=$(grep -c '^-[^-]' "$diff_file" || true)
+# All +/- lines minus the two --- / +++ header lines, so added and removed
+# lines that themselves start with + or - are still counted.
+added=$(( $(grep -c '^+' "$diff_file" || true) - $(grep -c '^+++ ' "$diff_file" || true) ))
+removed=$(( $(grep -c '^-' "$diff_file" || true) - $(grep -c '^--- ' "$diff_file" || true) ))
 lines=$(wc -l < "$diff_file" | tr -d ' ')
 bytes=$(wc -c < "$diff_file" | tr -d ' ')
 
@@ -55,17 +64,42 @@ ticks=$( { grep -o '`\{3,\}' "$diff_file" || true; } | awk '{ if ( length( $0 ) 
 fence=$(printf '%*s' $(( ticks > 2 ? ticks + 1 : 3 )) '' | tr ' ' '`')
 
 # Everything except the diff itself, sized with the longer, truncated wording,
-# decides how many bytes of diff fit.
-note=" Only the first ${hunks} of ${hunks} hunks are shown below; the download has them all."
-frame=$(printf '%s\n%s\n\n%s%s%s\n\n<details>\n<summary>corpus.diff (first %s of %s hunks)</summary>\n\n%sdiff\n%s\n</details>\n' \
+# decides how many bytes of diff fit. $( ) strips the trailing newline the
+# real output ends with; the extra 1 pays it back.
+note=" Only ${hunks} of ${hunks} hunks fit below; the download has them all."
+frame=$(printf '%s\n%s\n\n%s%s%s\n\n<details>\n<summary>corpus.diff (%s of %s hunks)</summary>\n\n%sdiff\n%s\n</details>\n' \
 	"$marker" "$heading" "$stat" "$note" "$download" "$hunks" "$hunks" "$fence" "$fence")
-budget=$(( max_bytes - ${#frame} ))
+budget=$(( max_bytes - ${#frame} - 1 ))
 
-# Last line and count of the leading whole hunks that fit the budget.
-read -r keep_line keep_hunks < <(awk -v budget="$budget" '
-	/^@@/ { if ( total <= budget ) { keep_line = NR - 1; keep_hunks = seen } seen++ }
-	{ total += length( $0 ) + 1 }
-	END { if ( total <= budget ) { keep_line = NR; keep_hunks = seen } print keep_line + 0, keep_hunks + 0 }
+# The whole hunks that fit the budget, in order, as a sed print script; the
+# file header before the first hunk rides along with the first kept hunk.
+{
+	read -r keep_hunks
+	read -r sed_script
+} < <(awk -v budget="$budget" '
+	# n must start numeric: uninitialized it is "", and the header bytes
+	# would land in size[""] where the budget never sees them.
+	BEGIN { n = 0 }
+	/^@@/ { n++; start[n] = NR }
+	{ size[n] += length( $0 ) + 1 }
+	END {
+		left = budget - size[0]
+		script = ""
+		for ( i = 1; i <= n; i++ ) {
+			if ( size[i] > left ) { continue }
+			left -= size[i]
+			kept++
+			last = ( i < n ) ? start[i + 1] - 1 : NR
+			script = script ";" start[i] "," last "p"
+		}
+		if ( kept && start[1] > 1 ) {
+			script = "1," ( start[1] - 1 ) "p" script
+		} else {
+			sub( /^;/, "", script )
+		}
+		print kept + 0
+		print script
+	}
 ' "$diff_file")
 
 if [ "$keep_hunks" -eq 0 ]; then
@@ -78,11 +112,11 @@ if [ "$keep_hunks" -eq "$hunks" ]; then
 	note=''
 	summary="corpus.diff (${lines} lines)"
 else
-	note=" Only the first ${keep_hunks} of ${hunks} hunks are shown below; the download has them all."
-	summary="corpus.diff (first ${keep_hunks} of ${hunks} hunks)"
+	note=" Only ${keep_hunks} of ${hunks} hunks fit below; the download has them all."
+	summary="corpus.diff (${keep_hunks} of ${hunks} hunks)"
 fi
 
 printf '%s\n%s\n\n%s%s%s\n\n<details>\n<summary>%s</summary>\n\n%sdiff\n' \
 	"$marker" "$heading" "$stat" "$note" "$download" "$summary" "$fence"
-head -n "$keep_line" "$diff_file"
+sed -n "$sed_script" "$diff_file"
 printf '%s\n</details>\n' "$fence"

--- a/tools/export-corpus.php
+++ b/tools/export-corpus.php
@@ -7,7 +7,10 @@
  * side-effect-free function library loaded by the Composer autoloader.
  *
  * The parser root is a parameter so one copy of this script can drive two
- * checkouts of the parser (base and head) over the same corpus.
+ * checkouts of the parser (base and head) over the same corpus. In CI the
+ * head checkout's copy drives both sides, so this script must call only
+ * WP_Parser API that exists on both: renaming or moving get_wp_files() or
+ * parse_files() breaks the base export until base has the rename too.
  *
  * Usage:
  *
@@ -43,4 +46,14 @@ require $parser_root . '/vendor/autoload.php';
 // error with a non-zero exit, so there is no return value to check here.
 $files = \WP_Parser\get_wp_files( $corpus_dir );
 
-echo json_encode( \WP_Parser\parse_files( $files, $corpus_dir ), JSON_PRETTY_PRINT ), PHP_EOL;
+$json = json_encode( \WP_Parser\parse_files( $files, $corpus_dir ), JSON_PRETTY_PRINT );
+
+// On false this would otherwise export an empty document with exit 0, and
+// two empty documents diff clean: a green check that verified nothing.
+// Malformed UTF-8 in parsed source is enough to trigger it.
+if ( false === $json ) {
+	fwrite( STDERR, 'json_encode failed: ' . json_last_error_msg() . PHP_EOL );
+	exit( 1 );
+}
+
+echo $json, PHP_EOL;


### PR DESCRIPTION
Follow-ups from review of #284, adjusted for #290 and #292.

**A failed run updates the comment instead of leaving the last one standing.** `Render report` ran only on success, and the `comment` job's `needs` implies `success()`, so any failure (export crash, size floor, `diff` exit 2) kept the previous push's report on the PR, reading as current. The report now renders unless the run is cancelled; on failure it replaces the comment with the failing sha and a run link. A missing `corpus.diff` is an error in the renderer, not "0 hunks". The comment lookup also filters on `github-actions[bot]`, so it never edits a human comment that happens to start with the marker.

**The renderer skips hunks that do not fit.** Truncation kept a prefix of whole hunks, so the first over-budget hunk hid every hunk after it. This corpus's export contains 84 KB lines (serialized argument defaults); one such hunk exceeds the whole 60 KB budget. Hunks larger than the remaining budget are now skipped, and the note says how many of the total are shown. Fixed in the same file: the budget was one byte too generous (command substitution strips the trailing newline, so an exact-fit body could exceed `MAX_BYTES` by one), the `+N`/`-N` stat missed added and removed lines that are empty or start with `+` or `-`, and the head sha is labeled "PR head, merged into base", since the export runs on the merge commit, not the branch tip.

**`export-corpus.php` fails when `json_encode` fails.** `json_encode` returns `false` on malformed UTF-8, which raw source bytes in argument defaults can carry. The script wrote a one-byte file and exited 0: CI then failed on the size floor with no cause named, and the README's local procedure read the empty diff as "no effect". Now: `json_last_error_msg()` on stderr, exit 1. The header also states the base-compatibility constraint: the head checkout's copy drives both sides, so it must call only `WP_Parser` API that exists on both.

**The README follows the pin.** #290 moved the pin to `.github/corpus-version`, but the README still pointed at `WP_CORPUS_TAG` in the workflow and hard-coded `7.0.4` three times; #292 bumped the pin to 7.1, so those lines are already stale. The local procedure now reads the pin file, fetches before computing the merge base, and ends with cleanup. Its work files are gitignored.

Not done, deliberately: diffing exporter stderr (base and head emit vendored deprecation notices with side-specific paths, so a naive diff is all noise), re-scoping the corpus cache (caches saved on `refs/pull/N/merge` only ever help re-pushes of the same PR; fixing that needs a seed job on master), and collapsing the renderer's several passes over the diff (under a second at real sizes).

Testing: renderer against synthetic diffs, with a `MAX_BYTES` sweep over 380 to 1200 asserting the body never exceeds the limit; the sweep caught an awk bug in the new selection (uninitialized `n` filed the header bytes under `size[""]`, outside the budget) before it shipped. Oversized hunk first and mid-stream, empty and missing file, and `+N`/`-N` against `git apply --numstat` all covered. Exporter: a corpus file with a `"\xff"` argument default exits 1 with the message; a clean corpus exports as before. Workflow: zizmor reports no findings; the failure branch was rendered by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
