### PR TITLE
Code snippets: Support "Outputs:" comments in runnable snippets

### DIFF
--- a/lib/runner.php
+++ b/lib/runner.php
@@ -1105,11 +1105,12 @@ function export_docblock_code_snippets( $text, &$setup_blueprints = null, $fence
  * comment delimiter, while any additional indentation becomes part of the
  * output. A final empty comment line preserves a final output newline.
  *
- * The older one-line form continues to accept a JSON string.
+ * Text after `// Outputs:` is one raw output line. The older one-line
+ * JSON-string form continues to work when that text starts with a double quote.
  *
  * @param string $code Snippet code extracted from a DocBlock fence.
  *
- * @throws \InvalidArgumentException When an Outputs comment is not a JSON string.
+ * @throws \InvalidArgumentException When a quoted Outputs comment is not a JSON string.
  *
  * @return array{code: string, expected_output: string|null} Runnable code and its optional output.
  */
@@ -1155,11 +1156,18 @@ function extract_docblock_php_snippet_output_comment( $code ) {
 		);
 	}
 
-	$output = json_decode( trim( $matches[1] ), true );
-	if ( JSON_ERROR_NONE !== json_last_error() || ! is_string( $output ) ) {
-		throw new \InvalidArgumentException(
-			'The trailing Outputs comment must contain one JSON string.'
-		);
+	$output = $matches[1];
+	if ( 0 === strpos( $output, ' ' ) ) {
+		$output = substr( $output, 1 );
+	}
+
+	if ( 0 === strpos( $output, '"' ) ) {
+		$output = json_decode( trim( $output ), true );
+		if ( JSON_ERROR_NONE !== json_last_error() || ! is_string( $output ) ) {
+			throw new \InvalidArgumentException(
+				'The trailing quoted Outputs comment must contain one JSON string.'
+			);
+		}
 	}
 
 	return array(

--- a/lib/runner.php
+++ b/lib/runner.php
@@ -1098,10 +1098,14 @@ function export_docblock_code_snippets( $text, &$setup_blueprints = null, $fence
 }
 
 /**
- * Extracts a trailing output comment from an interactive PHP snippet.
+ * Extracts trailing Outputs metadata from an interactive PHP snippet.
  *
- * The output value uses JSON-string syntax so punctuation, whitespace, and
- * escaped newlines retain their exact value in the exported JSON.
+ * A human-readable output block starts with `// Outputs:` and continues through
+ * the final consecutive `//` comment lines. One space after each `//` is a
+ * comment delimiter, while any additional indentation becomes part of the
+ * output. A final empty comment line preserves a final output newline.
+ *
+ * The older one-line form continues to accept a JSON string.
  *
  * @param string $code Snippet code extracted from a DocBlock fence.
  *
@@ -1110,12 +1114,41 @@ function export_docblock_code_snippets( $text, &$setup_blueprints = null, $fence
  * @return array{code: string, expected_output: string|null} Runnable code and its optional output.
  */
 function extract_docblock_php_snippet_output_comment( $code ) {
-	$lines      = explode( "\n", $code );
-	$last_line  = count( $lines ) - 1;
-	$comment    = $lines[ $last_line ];
-	$has_output = preg_match( '/^[ \t]*\/\/ Outputs:(.*)$/', $comment, $matches );
+	$lines                   = explode( "\n", $code );
+	$last_line               = count( $lines ) - 1;
+	$trailing_comment_start  = $last_line + 1;
+	$trailing_comment_lines  = array();
 
-	if ( ! $has_output ) {
+	for ( $line = $last_line; $line >= 0; $line-- ) {
+		if ( ! preg_match( '/^[ \t]*\/\/(.*)$/', $lines[ $line ], $matches ) ) {
+			break;
+		}
+
+		$trailing_comment_start         = $line;
+		$trailing_comment_lines[ $line ] = $matches[1];
+	}
+
+	for ( $line = $trailing_comment_start; $line <= $last_line; $line++ ) {
+		if ( ! isset( $trailing_comment_lines[ $line ] ) || ! preg_match( '/^ Outputs:[ \t]*$/', $trailing_comment_lines[ $line ] ) ) {
+			continue;
+		}
+
+		$output_lines = array();
+		for ( $output_line = $line + 1; $output_line <= $last_line; $output_line++ ) {
+			$value = $trailing_comment_lines[ $output_line ];
+			if ( 0 === strpos( $value, ' ' ) ) {
+				$value = substr( $value, 1 );
+			}
+			$output_lines[] = $value;
+		}
+
+		return array(
+			'code'            => rtrim( implode( "\n", array_slice( $lines, 0, $line ) ), "\n" ),
+			'expected_output' => implode( "\n", $output_lines ),
+		);
+	}
+
+	if ( ! preg_match( '/^[ \t]*\/\/ Outputs:(.*)$/', $lines[ $last_line ], $matches ) ) {
 		return array(
 			'code'            => $code,
 			'expected_output' => null,
@@ -1129,10 +1162,8 @@ function extract_docblock_php_snippet_output_comment( $code ) {
 		);
 	}
 
-	array_pop( $lines );
-
 	return array(
-		'code'            => rtrim( implode( "\n", $lines ), "\n" ),
+		'code'            => rtrim( implode( "\n", array_slice( $lines, 0, $last_line ) ), "\n" ),
 		'expected_output' => $output,
 	);
 }

--- a/lib/runner.php
+++ b/lib/runner.php
@@ -1105,9 +1105,9 @@ function export_docblock_code_snippets( $text, &$setup_blueprints = null, $fence
  * comment delimiter, while any additional indentation becomes part of the
  * output. A final empty comment line preserves a final output newline.
  *
- * The output form is inferred from the text after `// Outputs:`: a double quote
- * starts a JSON string, while other text is one raw output line. Quoting makes
- * trailing whitespace and escaped characters visible in a one-line output.
+ * Each output line is inferred separately: a double quote starts a JSON string,
+ * while other text is raw output. Quoting makes trailing whitespace and escaped
+ * characters visible in either a one-line or multiline output.
  *
  * @param string $code Snippet code extracted from a DocBlock fence.
  *
@@ -1141,7 +1141,7 @@ function extract_docblock_php_snippet_output_comment( $code ) {
 			if ( 0 === strpos( $value, ' ' ) ) {
 				$value = substr( $value, 1 );
 			}
-			$output_lines[] = $value;
+			$output_lines[] = decode_docblock_php_snippet_output_line( $value );
 		}
 
 		return array(
@@ -1162,20 +1162,35 @@ function extract_docblock_php_snippet_output_comment( $code ) {
 		$output = substr( $output, 1 );
 	}
 
-	if ( 0 === strpos( $output, '"' ) ) {
-		// A quoted inline value uses JSON to preserve the exact output string.
-		$output = json_decode( trim( $output ), true );
-		if ( JSON_ERROR_NONE !== json_last_error() || ! is_string( $output ) ) {
-			throw new \InvalidArgumentException(
-				'The trailing quoted Outputs comment must contain one JSON string.'
-			);
-		}
-	}
-
 	return array(
 		'code'            => rtrim( implode( "\n", array_slice( $lines, 0, $last_line ) ), "\n" ),
-		'expected_output' => $output,
+		'expected_output' => decode_docblock_php_snippet_output_line( $output ),
 	);
+}
+
+/**
+ * Decodes one line of output comment text.
+ *
+ * @param string $output One output line after its comment delimiter.
+ *
+ * @throws \InvalidArgumentException When a quoted output line is not a JSON string.
+ *
+ * @return string Raw or decoded output text.
+ */
+function decode_docblock_php_snippet_output_line( $output ) {
+	if ( 0 !== strpos( $output, '"' ) ) {
+		return $output;
+	}
+
+	// A quoted value uses JSON to preserve the exact output string.
+	$decoded = json_decode( trim( $output ), true );
+	if ( JSON_ERROR_NONE !== json_last_error() || ! is_string( $decoded ) ) {
+		throw new \InvalidArgumentException(
+			'A quoted Outputs comment must contain one JSON string.'
+		);
+	}
+
+	return $decoded;
 }
 
 /**

--- a/lib/runner.php
+++ b/lib/runner.php
@@ -1100,18 +1100,19 @@ function export_docblock_code_snippets( $text, &$setup_blueprints = null, $fence
 /**
  * Extracts trailing Outputs metadata from an interactive PHP snippet.
  *
- * A human-readable output block starts with `// Outputs:` and continues through
- * the final consecutive `//` comment lines. One space after each `//` is a
- * comment delimiter, while any additional indentation becomes part of the
- * output. A final empty comment line preserves a final output newline.
+ * `// Outputs:` declares literal output. Text on the same line is a one-line
+ * value. An empty header starts a block that continues through the final
+ * consecutive `//` comment lines. One space after each `//` is a comment
+ * delimiter, while any additional indentation becomes part of the output. A
+ * final empty comment line preserves a final output newline.
  *
- * Each output line is inferred separately: a double quote starts a JSON string,
- * while other text is raw output. Quoting makes trailing whitespace and escaped
- * characters visible in either a one-line or multiline output.
+ * `// Outputs (JSON-encoded):` declares one JSON string. This explicit form
+ * makes trailing whitespace and escaped characters visible without assigning
+ * special meaning to any literal output text.
  *
  * @param string $code Snippet code extracted from a DocBlock fence.
  *
- * @throws \InvalidArgumentException When a quoted Outputs comment is not a JSON string.
+ * @throws \InvalidArgumentException When an Outputs (JSON-encoded) comment is not a JSON string.
  *
  * @return array{code: string, expected_output: string|null} Runnable code and its optional output.
  */
@@ -1141,7 +1142,7 @@ function extract_docblock_php_snippet_output_comment( $code ) {
 			if ( 0 === strpos( $value, ' ' ) ) {
 				$value = substr( $value, 1 );
 			}
-			$output_lines[] = decode_docblock_php_snippet_output_line( $value );
+			$output_lines[] = $value;
 		}
 
 		return array(
@@ -1150,7 +1151,19 @@ function extract_docblock_php_snippet_output_comment( $code ) {
 		);
 	}
 
-	if ( ! preg_match( '/^[ \t]*\/\/ Outputs:(.*)$/', $lines[ $last_line ], $matches ) ) {
+	if ( preg_match( '/^[ \t]*\/\/ Outputs:(.*)$/', $lines[ $last_line ], $matches ) ) {
+		$output = $matches[1];
+		if ( 0 === strpos( $output, ' ' ) ) {
+			$output = substr( $output, 1 );
+		}
+
+		return array(
+			'code'            => rtrim( implode( "\n", array_slice( $lines, 0, $last_line ) ), "\n" ),
+			'expected_output' => $output,
+		);
+	}
+
+	if ( ! preg_match( '/^[ \t]*\/\/ Outputs \(JSON-encoded\):(.*)$/', $lines[ $last_line ], $matches ) ) {
 		return array(
 			'code'            => $code,
 			'expected_output' => null,
@@ -1162,35 +1175,17 @@ function extract_docblock_php_snippet_output_comment( $code ) {
 		$output = substr( $output, 1 );
 	}
 
-	return array(
-		'code'            => rtrim( implode( "\n", array_slice( $lines, 0, $last_line ) ), "\n" ),
-		'expected_output' => decode_docblock_php_snippet_output_line( $output ),
-	);
-}
-
-/**
- * Decodes one line of output comment text.
- *
- * @param string $output One output line after its comment delimiter.
- *
- * @throws \InvalidArgumentException When a quoted output line is not a JSON string.
- *
- * @return string Raw or decoded output text.
- */
-function decode_docblock_php_snippet_output_line( $output ) {
-	if ( 0 !== strpos( $output, '"' ) ) {
-		return $output;
-	}
-
-	// A quoted value uses JSON to preserve the exact output string.
 	$decoded = json_decode( trim( $output ), true );
 	if ( JSON_ERROR_NONE !== json_last_error() || ! is_string( $decoded ) ) {
 		throw new \InvalidArgumentException(
-			'A quoted Outputs comment must contain one JSON string.'
+			'The Outputs (JSON-encoded) comment must contain one JSON string.'
 		);
 	}
 
-	return $decoded;
+	return array(
+		'code'            => rtrim( implode( "\n", array_slice( $lines, 0, $last_line ) ), "\n" ),
+		'expected_output' => $decoded,
+	);
 }
 
 /**

--- a/lib/runner.php
+++ b/lib/runner.php
@@ -1094,28 +1094,30 @@ function export_docblock_code_snippets( $text, &$setup_blueprints = null, $fence
  * @return array{code: string, expected_output: string|null} Runnable code and its optional output.
  */
 function extract_docblock_php_snippet_output_comment( $code ) {
-	$lines                   = explode( "\n", $code );
-	$last_line               = count( $lines ) - 1;
-	$trailing_comment_start  = $last_line + 1;
-	$trailing_comment_lines  = array();
-
-	for ( $line = $last_line; $line >= 0; $line-- ) {
-		if ( ! preg_match( '/^[ \t]*\/\/(.*)$/', $lines[ $line ], $matches ) ) {
-			break;
-		}
-
-		$trailing_comment_start         = $line;
-		$trailing_comment_lines[ $line ] = $matches[1];
+	if ( false === strpos( $code, '// Outputs' ) ) {
+		return array(
+			'code'            => $code,
+			'expected_output' => null,
+		);
 	}
 
-	for ( $line = $trailing_comment_start; $line <= $last_line; $line++ ) {
-		if ( ! isset( $trailing_comment_lines[ $line ] ) || ! preg_match( '/^ Outputs:[ \t]*$/', $trailing_comment_lines[ $line ] ) ) {
+	$comments = parse_trailing_docblock_php_snippet_line_comments( $code );
+	if ( empty( $comments ) ) {
+		return array(
+			'code'            => $code,
+			'expected_output' => null,
+		);
+	}
+
+	foreach ( $comments as $comment_index => $comment ) {
+		$value = substr( $comment['text'], 2 );
+		if ( ' Outputs:' !== rtrim( $value, " \t" ) ) {
 			continue;
 		}
 
 		$output_lines = array();
-		for ( $output_line = $line + 1; $output_line <= $last_line; $output_line++ ) {
-			$value = $trailing_comment_lines[ $output_line ];
+		foreach ( array_slice( $comments, $comment_index + 1 ) as $output_comment ) {
+			$value = substr( $output_comment['text'], 2 );
 			if ( 0 === strpos( $value, ' ' ) ) {
 				$value = substr( $value, 1 );
 			}
@@ -1123,31 +1125,33 @@ function extract_docblock_php_snippet_output_comment( $code ) {
 		}
 
 		return array(
-			'code'            => rtrim( implode( "\n", array_slice( $lines, 0, $line ) ), "\n" ),
+			'code'            => rtrim( substr( $code, 0, $comment['line_start'] ), "\n" ),
 			'expected_output' => implode( "\n", $output_lines ),
 		);
 	}
 
-	if ( preg_match( '/^[ \t]*\/\/ Outputs:(.*)$/', $lines[ $last_line ], $matches ) ) {
-		$output = $matches[1];
+	$comment = end( $comments );
+	$value   = substr( $comment['text'], 2 );
+	if ( 0 === strpos( $value, ' Outputs:' ) ) {
+		$output = substr( $value, strlen( ' Outputs:' ) );
 		if ( 0 === strpos( $output, ' ' ) ) {
 			$output = substr( $output, 1 );
 		}
 
 		return array(
-			'code'            => rtrim( implode( "\n", array_slice( $lines, 0, $last_line ) ), "\n" ),
+			'code'            => rtrim( substr( $code, 0, $comment['line_start'] ), "\n" ),
 			'expected_output' => $output,
 		);
 	}
 
-	if ( ! preg_match( '/^[ \t]*\/\/ Outputs \(JSON-encoded\):(.*)$/', $lines[ $last_line ], $matches ) ) {
+	if ( 0 !== strpos( $value, ' Outputs (JSON-encoded):' ) ) {
 		return array(
 			'code'            => $code,
 			'expected_output' => null,
 		);
 	}
 
-	$output = $matches[1];
+	$output = substr( $value, strlen( ' Outputs (JSON-encoded):' ) );
 	if ( 0 === strpos( $output, ' ' ) ) {
 		$output = substr( $output, 1 );
 	}
@@ -1160,9 +1164,65 @@ function extract_docblock_php_snippet_output_comment( $code ) {
 	}
 
 	return array(
-		'code'            => rtrim( implode( "\n", array_slice( $lines, 0, $last_line ) ), "\n" ),
+		'code'            => rtrim( substr( $code, 0, $comment['line_start'] ), "\n" ),
 		'expected_output' => $decoded,
 	);
+}
+
+/**
+ * Parses the consecutive standalone PHP line comments at the end of a snippet.
+ *
+ * @param string $code Snippet code extracted from a DocBlock fence.
+ *
+ * @return array<int, array{text: string, start: int, line_start: int}> Comments in source order.
+ */
+function parse_trailing_docblock_php_snippet_line_comments( $code ) {
+	// Force snippets without an opening tag into PHP mode. Do not use TOKEN_PARSE:
+	// documentation snippets may be partial programs that are still valid examples.
+	$tokens = token_get_all( "<?php\n" . $code );
+	array_shift( $tokens );
+
+	$comments   = array();
+	$offset     = 0;
+	$line_start = 0;
+	foreach ( $tokens as $token ) {
+		$id   = is_array( $token ) ? $token[0] : null;
+		$text = is_array( $token ) ? $token[1] : $token;
+		$is_standalone_line_comment =
+			T_COMMENT === $id &&
+			0 === strpos( $text, '//' ) &&
+			'' === trim( substr( $code, $line_start, $offset - $line_start ), " \t" );
+
+		if ( $is_standalone_line_comment ) {
+			// PHP versions differ on whether a line comment token includes its newline.
+			$comment_text = "\n" === substr( $text, -1 ) ? substr( $text, 0, -1 ) : $text;
+
+			if ( ! empty( $comments ) ) {
+				$previous     = end( $comments );
+				$previous_end = $previous['start'] + strlen( $previous['text'] );
+				$separator    = substr( $code, $previous_end, $line_start - $previous_end );
+				if ( 1 !== substr_count( $separator, "\n" ) || '' !== trim( $separator, " \t\n" ) ) {
+					$comments = array();
+				}
+			}
+
+			$comments[] = array(
+				'text'       => $comment_text,
+				'start'      => $offset,
+				'line_start' => $line_start,
+			);
+		} elseif ( T_WHITESPACE !== $id ) {
+			$comments = array();
+		}
+
+		$last_newline = strrpos( $text, "\n" );
+		if ( false !== $last_newline ) {
+			$line_start = $offset + $last_newline + 1;
+		}
+		$offset += strlen( $text );
+	}
+
+	return $comments;
 }
 
 /**

--- a/lib/runner.php
+++ b/lib/runner.php
@@ -996,6 +996,11 @@ function export_docblock_code_snippets( $text, &$setup_blueprints = null, $fence
 			'type' => 'php-code-snippet',
 			'code' => $fences[ $i ]['code'],
 		);
+		$output_comment = extract_docblock_php_snippet_output_comment( $snippet['code'] );
+		$snippet['code'] = $output_comment['code'];
+		if ( null !== $output_comment['expected_output'] ) {
+			$snippet['expected_output'] = $output_comment['expected_output'];
+		}
 
 		if ( null !== $fences[ $i ]['referenced_setup'] ) {
 			$snippet['blueprint'] = $fences[ $i ]['referenced_setup'];
@@ -1031,6 +1036,13 @@ function export_docblock_code_snippets( $text, &$setup_blueprints = null, $fence
 
 			if ( $fences[ $j ]['is_expected_output'] ) {
 				// First expected-output fence ends the run, so a snippet takes one.
+				if ( array_key_exists( 'expected_output', $snippet ) ) {
+					throw new \InvalidArgumentException(
+						'Interactive PHP fence on line ' . ( $fences[ $i ]['start'] + 1 ) .
+						' of the long description declares output both in code and in an expected-output fence.'
+					);
+				}
+
 				$snippet['expected_output'] = $fences[ $j ]['code'];
 				$consumed_fences[ $j ]      = true;
 				break;
@@ -1083,6 +1095,46 @@ function export_docblock_code_snippets( $text, &$setup_blueprints = null, $fence
 	}
 
 	return $snippets;
+}
+
+/**
+ * Extracts a trailing output comment from an interactive PHP snippet.
+ *
+ * The output value uses JSON-string syntax so punctuation, whitespace, and
+ * escaped newlines retain their exact value in the exported JSON.
+ *
+ * @param string $code Snippet code extracted from a DocBlock fence.
+ *
+ * @throws \InvalidArgumentException When an Outputs comment is not a JSON string.
+ *
+ * @return array{code: string, expected_output: string|null} Runnable code and its optional output.
+ */
+function extract_docblock_php_snippet_output_comment( $code ) {
+	$lines      = explode( "\n", $code );
+	$last_line  = count( $lines ) - 1;
+	$comment    = $lines[ $last_line ];
+	$has_output = preg_match( '/^[ \t]*\/\/ Outputs:(.*)$/', $comment, $matches );
+
+	if ( ! $has_output ) {
+		return array(
+			'code'            => $code,
+			'expected_output' => null,
+		);
+	}
+
+	$output = json_decode( trim( $matches[1] ), true );
+	if ( JSON_ERROR_NONE !== json_last_error() || ! is_string( $output ) ) {
+		throw new \InvalidArgumentException(
+			'The trailing Outputs comment must contain one JSON string.'
+		);
+	}
+
+	array_pop( $lines );
+
+	return array(
+		'code'            => rtrim( implode( "\n", $lines ), "\n" ),
+		'expected_output' => $output,
+	);
 }
 
 /**

--- a/lib/runner.php
+++ b/lib/runner.php
@@ -1105,8 +1105,9 @@ function export_docblock_code_snippets( $text, &$setup_blueprints = null, $fence
  * comment delimiter, while any additional indentation becomes part of the
  * output. A final empty comment line preserves a final output newline.
  *
- * Text after `// Outputs:` is one raw output line. The older one-line
- * JSON-string form continues to work when that text starts with a double quote.
+ * The output form is inferred from the text after `// Outputs:`: a double quote
+ * starts a JSON string, while other text is one raw output line. Quoting makes
+ * trailing whitespace and escaped characters visible in a one-line output.
  *
  * @param string $code Snippet code extracted from a DocBlock fence.
  *
@@ -1162,6 +1163,7 @@ function extract_docblock_php_snippet_output_comment( $code ) {
 	}
 
 	if ( 0 === strpos( $output, '"' ) ) {
+		// A quoted inline value uses JSON to preserve the exact output string.
 		$output = json_decode( trim( $output ), true );
 		if ( JSON_ERROR_NONE !== json_last_error() || ! is_string( $output ) ) {
 			throw new \InvalidArgumentException(

--- a/lib/runner.php
+++ b/lib/runner.php
@@ -811,14 +811,12 @@ function get_docblock_code_fences( $text ) {
 			validate_docblock_setup_blueprint_name( $setup_name, $fence['start'] );
 		}
 
-		$is_expected_output = 'expected-output' === $fence['language'] && 1 === count( $info_parts );
-		$is_blueprint       = 'setup-blueprint' === $fence['language'] && 1 === count( $info_parts );
+		$is_blueprint = 'setup-blueprint' === $fence['language'] && 1 === count( $info_parts );
 		$fences[ $key ]['referenced_setup']   = $referenced_setup;
 		$fences[ $key ]['is_interactive_php'] = $is_interactive_php;
-		$fences[ $key ]['is_expected_output'] = $is_expected_output;
 		$fences[ $key ]['is_blueprint']       = $is_blueprint;
 		$fences[ $key ]['setup_name']         = $setup_name;
-		$fences[ $key ]['is_code_snippet']    = $is_interactive_php || $is_expected_output || $is_blueprint || null !== $setup_name;
+		$fences[ $key ]['is_code_snippet']    = $is_interactive_php || $is_blueprint || null !== $setup_name;
 	}
 
 	// Number the interactive PHP fences so the exporter and the stripper agree on each
@@ -1034,20 +1032,6 @@ function export_docblock_code_snippets( $text, &$setup_blueprints = null, $fence
 				break;
 			}
 
-			if ( $fences[ $j ]['is_expected_output'] ) {
-				// First expected-output fence ends the run, so a snippet takes one.
-				if ( array_key_exists( 'expected_output', $snippet ) ) {
-					throw new \InvalidArgumentException(
-						'Interactive PHP fence on line ' . ( $fences[ $i ]['start'] + 1 ) .
-						' of the long description declares output both in code and in an expected-output fence.'
-					);
-				}
-
-				$snippet['expected_output'] = $fences[ $j ]['code'];
-				$consumed_fences[ $j ]      = true;
-				break;
-			}
-
 			if ( null !== $fences[ $j ]['setup_name'] ) {
 				break;
 			}
@@ -1077,13 +1061,6 @@ function export_docblock_code_snippets( $text, &$setup_blueprints = null, $fence
 	foreach ( $fences as $index => $fence ) {
 		if ( isset( $consumed_fences[ $index ] ) ) {
 			continue;
-		}
-
-		if ( $fence['is_expected_output'] ) {
-			throw new \InvalidArgumentException(
-				'Expected-output fence on line ' . ( $fence['start'] + 1 ) .
-				' of the long description is not attached to an interactive PHP fence.'
-			);
 		}
 
 		if ( $fence['is_blueprint'] ) {
@@ -1239,7 +1216,7 @@ function strip_docblock_code_snippet_fences( $text, $fences = null ) {
 		// Interactive PHP fences become `code_snippets` entries. A plain HTML
 		// comment survives Markdown rendering, `the_content`, and block parsing,
 		// allowing the theme to replace it in place between the surrounding prose.
-		// Snippet-metadata fences (expected-output, Blueprints) are removed.
+		// Snippet-metadata fences containing Blueprints are removed.
 		for ( $i = $fence['start']; $i <= $fence['end']; $i++ ) {
 			if ( $fence['is_interactive_php'] && $i === $fence['start'] ) {
 				// Keep a nested fence's indentation so Markdown leaves the replacement

--- a/lib/runner.php
+++ b/lib/runner.php
@@ -811,12 +811,14 @@ function get_docblock_code_fences( $text ) {
 			validate_docblock_setup_blueprint_name( $setup_name, $fence['start'] );
 		}
 
-		$is_blueprint = 'setup-blueprint' === $fence['language'] && 1 === count( $info_parts );
+		$is_expected_output = 'expected-output' === $fence['language'] && 1 === count( $info_parts );
+		$is_blueprint       = 'setup-blueprint' === $fence['language'] && 1 === count( $info_parts );
 		$fences[ $key ]['referenced_setup']   = $referenced_setup;
 		$fences[ $key ]['is_interactive_php'] = $is_interactive_php;
+		$fences[ $key ]['is_expected_output'] = $is_expected_output;
 		$fences[ $key ]['is_blueprint']       = $is_blueprint;
 		$fences[ $key ]['setup_name']         = $setup_name;
-		$fences[ $key ]['is_code_snippet']    = $is_interactive_php || $is_blueprint || null !== $setup_name;
+		$fences[ $key ]['is_code_snippet']    = $is_interactive_php || $is_expected_output || $is_blueprint || null !== $setup_name;
 	}
 
 	// Number the interactive PHP fences so the exporter and the stripper agree on each
@@ -1032,6 +1034,20 @@ function export_docblock_code_snippets( $text, &$setup_blueprints = null, $fence
 				break;
 			}
 
+			if ( $fences[ $j ]['is_expected_output'] ) {
+				// First expected-output fence ends the run, so a snippet takes one.
+				if ( array_key_exists( 'expected_output', $snippet ) ) {
+					throw new \InvalidArgumentException(
+						'Interactive PHP fence on line ' . ( $fences[ $i ]['start'] + 1 ) .
+						' of the long description declares output both in code and in an expected-output fence.'
+					);
+				}
+
+				$snippet['expected_output'] = $fences[ $j ]['code'];
+				$consumed_fences[ $j ]      = true;
+				break;
+			}
+
 			if ( null !== $fences[ $j ]['setup_name'] ) {
 				break;
 			}
@@ -1061,6 +1077,13 @@ function export_docblock_code_snippets( $text, &$setup_blueprints = null, $fence
 	foreach ( $fences as $index => $fence ) {
 		if ( isset( $consumed_fences[ $index ] ) ) {
 			continue;
+		}
+
+		if ( $fence['is_expected_output'] ) {
+			throw new \InvalidArgumentException(
+				'Expected-output fence on line ' . ( $fence['start'] + 1 ) .
+				' of the long description is not attached to an interactive PHP fence.'
+			);
 		}
 
 		if ( $fence['is_blueprint'] ) {
@@ -1278,7 +1301,7 @@ function strip_docblock_code_snippet_fences( $text, $fences = null ) {
 		// Interactive PHP fences become `code_snippets` entries. A plain HTML
 		// comment survives Markdown rendering, `the_content`, and block parsing,
 		// allowing the theme to replace it in place between the surrounding prose.
-		// Snippet-metadata fences containing Blueprints are removed.
+		// Snippet-metadata fences (expected-output, Blueprints) are removed.
 		for ( $i = $fence['start']; $i <= $fence['end']; $i++ ) {
 			if ( $fence['is_interactive_php'] && $i === $fence['start'] ) {
 				// Keep a nested fence's indentation so Markdown leaves the replacement

--- a/lib/runner.php
+++ b/lib/runner.php
@@ -1177,26 +1177,28 @@ function extract_docblock_php_snippet_output_comment( $code ) {
  * @return array<int, array{text: string, start: int, line_start: int}> Comments in source order.
  */
 function parse_trailing_docblock_php_snippet_line_comments( $code ) {
-	// Force snippets without an opening tag into PHP mode. Do not use TOKEN_PARSE:
-	// documentation snippets may be partial programs that are still valid examples.
-	$tokens = token_get_all( "<?php\n" . $code );
+	// PHP-Parser's emulative lexer normalizes token shapes across PHP versions.
+	// Prefixing forces snippets without an opening tag into PHP mode.
+	$lexer  = new \PhpParser\Lexer\Emulative();
+	$tokens = $lexer->tokenize(
+		"<?php\n" . $code,
+		new \PhpParser\ErrorHandler\Collecting()
+	);
 	array_shift( $tokens );
+	array_pop( $tokens );
 
 	$comments   = array();
 	$offset     = 0;
 	$line_start = 0;
 	foreach ( $tokens as $token ) {
-		$id   = is_array( $token ) ? $token[0] : null;
-		$text = is_array( $token ) ? $token[1] : $token;
+		$id   = $token->id;
+		$text = $token->text;
 		$is_standalone_line_comment =
 			T_COMMENT === $id &&
 			0 === strpos( $text, '//' ) &&
 			'' === trim( substr( $code, $line_start, $offset - $line_start ), " \t" );
 
 		if ( $is_standalone_line_comment ) {
-			// PHP versions differ on whether a line comment token includes its newline.
-			$comment_text = "\n" === substr( $text, -1 ) ? substr( $text, 0, -1 ) : $text;
-
 			if ( ! empty( $comments ) ) {
 				$previous     = end( $comments );
 				$previous_end = $previous['start'] + strlen( $previous['text'] );
@@ -1207,7 +1209,7 @@ function parse_trailing_docblock_php_snippet_line_comments( $code ) {
 			}
 
 			$comments[] = array(
-				'text'       => $comment_text,
+				'text'       => $text,
 				'start'      => $offset,
 				'line_start' => $line_start,
 			);

--- a/tests/phpunit/tests/export/docblocks.inc
+++ b/tests/phpunit/tests/export/docblocks.inc
@@ -60,10 +60,7 @@ class Test_Class {
 	 * @unlink( '/tmp/phpdoc-parser-property' );
 	 * require '/wordpress/wp-load.php';
 	 * echo docs_file_greeting();
-	 * ```
-	 *
-	 * ```expected-output
-	 * Hello from the file setup
+	 * // Outputs: Hello from the file setup
 	 * ```
 	 *
 	 * @since 3.0.0
@@ -135,20 +132,14 @@ class Test_Class {
 	 * <?php
 	 * require '/wordpress/wp-load.php';
 	 * echo docs_shared_greeting( 'first' );
-	 * ```
-	 *
-	 * ```expected-output
-	 * Hello, first
+	 * // Outputs: Hello, first
 	 * ```
 	 *
 	 * ```php interactive setup-blueprint=shared-greeting
 	 * <?php
 	 * require '/wordpress/wp-load.php';
 	 * echo docs_shared_greeting( 'second' );
-	 * ```
-	 *
-	 * ```expected-output
-	 * Hello, second
+	 * // Outputs: Hello, second
 	 * ```
 	 *
 	 * @since 6.9.0
@@ -163,10 +154,7 @@ class Test_Class {
 	 * <?php
 	 * require '/wordpress/wp-load.php';
 	 * echo docs_file_greeting();
-	 * ```
-	 *
-	 * ```expected-output
-	 * Hello from the file setup
+	 * // Outputs: Hello from the file setup
 	 * ```
 	 *
 	 * @since 6.9.0
@@ -192,10 +180,7 @@ $var = apply_filters_ref_array( 'test_ref_array_filter', array( &$var ) );
  * <?php
  * require '/wordpress/wp-load.php';
  * echo docs_file_greeting();
- * ```
- *
- * ```expected-output
- * Hello from the file setup
+ * // Outputs: Hello from the file setup
  * ```
  *
  * @since 3.7.0

--- a/tests/phpunit/tests/export/docblocks.inc
+++ b/tests/phpunit/tests/export/docblocks.inc
@@ -107,7 +107,8 @@ class Test_Class {
 	 * <?php
 	 * require '/wordpress/wp-load.php';
 	 * echo docs_fixture_greeting();
-	 * // Outputs: "Hello from a method"
+	 * // Outputs:
+	 * // Hello from a method
 	 * ```
 	 *
 	 * @since 6.9.0

--- a/tests/phpunit/tests/export/docblocks.inc
+++ b/tests/phpunit/tests/export/docblocks.inc
@@ -107,10 +107,7 @@ class Test_Class {
 	 * <?php
 	 * require '/wordpress/wp-load.php';
 	 * echo docs_fixture_greeting();
-	 * ```
-	 *
-	 * ```expected-output
-	 * Hello from a method
+	 * // Outputs: "Hello from a method"
 	 * ```
 	 *
 	 * @since 6.9.0

--- a/tests/phpunit/tests/export/docblocks.php
+++ b/tests/phpunit/tests/export/docblocks.php
@@ -525,7 +525,7 @@ class Export_Docblocks extends Export_UnitTestCase {
 					'foreach ( $p->class_list() as $class_name ) {',
 					'  echo "{$class_name} ";',
 					'}',
-					'// Outputs: "free <egg> lang-en "',
+					'// Outputs (JSON-encoded): "free <egg> lang-en "',
 					'```',
 				)
 			)
@@ -566,6 +566,18 @@ class Export_Docblocks extends Export_UnitTestCase {
 			),
 			$snippets
 		);
+	}
+
+	/**
+	 * Test that quotes in literal one-line output remain output text.
+	 */
+	public function test_inline_code_snippet_output_comment_preserves_quotes() {
+
+		$snippets = \WP_Parser\export_docblock_code_snippets(
+			"```php interactive\necho 'example';\n// Outputs: \"second \"\n```"
+		);
+
+		$this->assertSame( '"second "', $snippets[0]['expected_output'] );
 	}
 
 	/**
@@ -618,23 +630,23 @@ class Export_Docblocks extends Export_UnitTestCase {
 	}
 
 	/**
-	 * Test that quoted output lines preserve trailing whitespace and newlines.
+	 * Test that literal output preserves quotes and trailing newlines.
 	 */
-	public function test_multiline_code_snippet_output_comment_preserves_trailing_whitespace() {
+	public function test_multiline_code_snippet_output_comment_preserves_literal_text() {
 
 		$snippets = \WP_Parser\export_docblock_code_snippets(
 			"```php interactive\necho 'done';\n// Outputs:\n// first\n// \"second \"\n//\n//\n```"
 		);
 
-		$this->assertSame( "first\nsecond \n\n", $snippets[0]['expected_output'] );
+		$this->assertSame( "first\n\"second \"\n\n", $snippets[0]['expected_output'] );
 	}
 
 	/**
-	 * Test that quoted Outputs comments retain their output value.
+	 * Test that JSON-encoded Outputs comments retain their output value.
 	 *
-	 * @dataProvider quoted_code_snippet_output_comments
+	 * @dataProvider json_encoded_code_snippet_output_comments
 	 */
-	public function test_quoted_code_snippet_output_comments( $comment, $expected_output ) {
+	public function test_json_encoded_code_snippet_output_comments( $comment, $expected_output ) {
 
 		$snippets = \WP_Parser\export_docblock_code_snippets(
 			"```php interactive\necho 'example';\n" . $comment . "\n```"
@@ -653,26 +665,30 @@ class Export_Docblocks extends Export_UnitTestCase {
 	}
 
 	/**
-	 * Returns quoted output comments with formatting that must survive export.
+	 * Returns JSON-encoded output comments with formatting that must survive export.
 	 */
-	public function quoted_code_snippet_output_comments() {
+	public function json_encoded_code_snippet_output_comments() {
 
 		return array(
-			'quoted output preserves trailing whitespace' => array(
-				'// Outputs: "ends with a space "',
+			'JSON string preserves trailing whitespace' => array(
+				'// Outputs (JSON-encoded): "ends with a space "',
 				'ends with a space ',
 			),
-			'multiline output with a trailing newline' => array(
-				'// Outputs: "first\\nsecond\\n"',
+			'JSON string preserves multiline output with a trailing newline' => array(
+				'// Outputs (JSON-encoded): "first\\nsecond\\n"',
 				"first\nsecond\n",
 			),
 			'escaped quotes and tabs' => array(
-				'// Outputs: "A \\"quote\\" and a \\t tab"',
+				'// Outputs (JSON-encoded): "A \\"quote\\" and a \\t tab"',
 				"A \"quote\" and a \t tab",
 			),
 			'whitespace after the JSON string is not output' => array(
-				'// Outputs: "done"   ',
+				'// Outputs (JSON-encoded): "done"   ',
 				'done',
+			),
+			'literal Unicode remains readable' => array(
+				'// Outputs (JSON-encoded): "✅ Complete "',
+				'✅ Complete ',
 			),
 		);
 	}
@@ -698,15 +714,28 @@ class Export_Docblocks extends Export_UnitTestCase {
 	}
 
 	/**
-	 * Test that a quoted Outputs comment must use valid JSON-string syntax.
+	 * Test that a JSON-encoded Outputs comment must contain a JSON string.
+	 *
+	 * @dataProvider invalid_json_encoded_code_snippet_output_comments
 	 */
-	public function test_quoted_code_snippet_output_comment_requires_json_string() {
+	public function test_json_encoded_code_snippet_output_comment_requires_json_string( $output ) {
 
 		$this->expectException( \InvalidArgumentException::class );
-		$this->expectExceptionMessage( 'A quoted Outputs comment must contain one JSON string.' );
+		$this->expectExceptionMessage( 'The Outputs (JSON-encoded) comment must contain one JSON string.' );
 
 		\WP_Parser\export_docblock_code_snippets(
-			"```php interactive\necho 'one';\n// Outputs: \"one\n```"
+			"```php interactive\necho 'one';\n// Outputs (JSON-encoded): " . $output . "\n```"
+		);
+	}
+
+	/**
+	 * Returns invalid JSON-encoded output values.
+	 */
+	public function invalid_json_encoded_code_snippet_output_comments() {
+
+		return array(
+			'malformed JSON' => array( '"one' ),
+			'JSON value is not a string' => array( '1' ),
 		);
 	}
 
@@ -719,7 +748,7 @@ class Export_Docblocks extends Export_UnitTestCase {
 		$this->expectExceptionMessage( 'declares output both in code and in an expected-output fence' );
 
 		\WP_Parser\export_docblock_code_snippets(
-			"```php interactive\necho 'one';\n// Outputs: \"one\"\n```\n```expected-output\none\n```"
+			"```php interactive\necho 'one';\n// Outputs (JSON-encoded): \"one\"\n```\n```expected-output\none\n```"
 		);
 	}
 

--- a/tests/phpunit/tests/export/docblocks.php
+++ b/tests/phpunit/tests/export/docblocks.php
@@ -576,6 +576,18 @@ class Export_Docblocks extends Export_UnitTestCase {
 	}
 
 	/**
+	 * Test that an expected-output fence remains supported for compatibility.
+	 */
+	public function test_expected_output_fence_remains_supported() {
+
+		$description = "```php interactive\necho 'example';\n```\n```expected-output\nexample\n```";
+		$snippets    = \WP_Parser\export_docblock_code_snippets( $description );
+
+		$this->assertSame( 'example', $snippets[0]['expected_output'] );
+		$this->assertStringNotContainsString( 'expected-output', \WP_Parser\strip_docblock_code_snippet_fences( $description ) );
+	}
+
+	/**
 	 * Test that a trailing Outputs comment block exports human-readable output.
 	 */
 	public function test_multiline_code_snippet_output_comment() {
@@ -742,6 +754,19 @@ class Export_Docblocks extends Export_UnitTestCase {
 	}
 
 	/**
+	 * Test that code-comment output cannot conflict with an expected-output fence.
+	 */
+	public function test_code_snippet_output_comment_and_fence_cannot_both_define_output() {
+
+		$this->expectException( \InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'declares output both in code and in an expected-output fence' );
+
+		\WP_Parser\export_docblock_code_snippets(
+			"```php interactive\necho 'one';\n// Outputs (JSON-encoded): \"one\"\n```\n```expected-output\none\n```"
+		);
+	}
+
+	/**
 	 * Test that a JSON-encoded Outputs comment must contain a JSON string.
 	 *
 	 * @dataProvider invalid_json_encoded_code_snippet_output_comments
@@ -797,7 +822,6 @@ class Export_Docblocks extends Export_UnitTestCase {
 			'collapsed Blueprint reference' => array( 'php interactive setupblueprint=shared', $php ),
 			'unsupported interactive option' => array( 'php interactive editable=false', $php ),
 			'output alias' => array( 'output', 'output' ),
-			'expected output fence' => array( 'expected-output', 'output' ),
 			'underscored expected output' => array( 'expected_output', 'output' ),
 			'typed expected output' => array( 'text/expected-output', 'output' ),
 			'uppercase PHP' => array( 'PHP interactive', $php ),
@@ -1321,8 +1345,11 @@ class Export_Docblocks extends Export_UnitTestCase {
 		$php = "```php interactive\n<?php echo 1;\n```";
 
 		return array(
+			'expected output before PHP' => array( "```expected-output\n1\n```\n" . $php ),
+			'expected output after prose' => array( $php . "\nProse.\n```expected-output\n1\n```" ),
 			'inline Blueprint before prose' => array( "```setup-blueprint\n{}\n```\nProse.\n" . $php ),
 			'inline Blueprint after prose' => array( $php . "\nProse.\n```setup-blueprint\n{}\n```" ),
+			'duplicate expected output' => array( $php . "\n```expected-output\n1\n```\n```expected-output\n2\n```" ),
 		);
 	}
 

--- a/tests/phpunit/tests/export/docblocks.php
+++ b/tests/phpunit/tests/export/docblocks.php
@@ -548,6 +548,70 @@ class Export_Docblocks extends Export_UnitTestCase {
 	}
 
 	/**
+	 * Test that JSON escapes in a trailing Outputs comment retain their output value.
+	 *
+	 * @dataProvider trailing_code_snippet_output_comments
+	 */
+	public function test_trailing_code_snippet_output_comments( $comment, $expected_output ) {
+
+		$snippets = \WP_Parser\export_docblock_code_snippets(
+			"```php interactive\necho 'example';\n" . $comment . "\n```"
+		);
+
+		$this->assertSame(
+			array(
+				array(
+					'type' => 'php-code-snippet',
+					'code' => "echo 'example';",
+					'expected_output' => $expected_output,
+				),
+			),
+			$snippets
+		);
+	}
+
+	/**
+	 * Returns JSON-string output comments with escaping that must survive export.
+	 */
+	public function trailing_code_snippet_output_comments() {
+
+		return array(
+			'multiline output with a trailing newline' => array(
+				'// Outputs: "first\\nsecond\\n"',
+				"first\nsecond\n",
+			),
+			'escaped quotes and tabs' => array(
+				'// Outputs: "A \\"quote\\" and a \\t tab"',
+				"A \"quote\" and a \t tab",
+			),
+			'whitespace after the JSON string is not output' => array(
+				'// Outputs: "done"   ',
+				'done',
+			),
+		);
+	}
+
+	/**
+	 * Test that an Outputs comment before further code remains part of the snippet.
+	 */
+	public function test_non_trailing_code_snippet_output_comment_remains_code() {
+
+		$snippets = \WP_Parser\export_docblock_code_snippets(
+			"```php interactive\necho 'before';\n// Outputs: \"before\"\necho 'after';\n```"
+		);
+
+		$this->assertSame(
+			array(
+				array(
+					'type' => 'php-code-snippet',
+					'code' => "echo 'before';\n// Outputs: \"before\"\necho 'after';",
+				),
+			),
+			$snippets
+		);
+	}
+
+	/**
 	 * Test that a trailing Outputs comment must use JSON-string syntax.
 	 */
 	public function test_code_snippet_output_comment_requires_json_string() {

--- a/tests/phpunit/tests/export/docblocks.php
+++ b/tests/phpunit/tests/export/docblocks.php
@@ -361,22 +361,22 @@ class Export_Docblocks extends Export_UnitTestCase {
 	public function code_snippet_fence_delimiters() {
 		return array(
 			'smaller runs stay inside a larger fence' => array(
-				"````php interactive\n<?php\n```\necho 'inside';\n```\n````\n````expected-output\nouter\n````",
+				"````php interactive\n<?php\n```\necho 'inside';\n```\n// Outputs: outer\n````",
 				"<?php\n```\necho 'inside';\n```",
 				'outer',
 			),
 			'different runs and text do not close a fence' => array(
-				"```php interactive\n<?php\n````\necho 'inside';\n``` not a closer\necho 'still inside';\n```\n```expected-output\nexact\n```",
+				"```php interactive\n<?php\n````\necho 'inside';\n``` not a closer\necho 'still inside';\n// Outputs: exact\n```",
 				"<?php\n````\necho 'inside';\n``` not a closer\necho 'still inside';",
 				'exact',
 			),
 			'arbitrary indentation is removed from content' => array(
-				"    ```php interactive\n    <?php\n      echo 'indented';\n\t```\n    ```expected-output\n    indented\n```",
+				"    ```php interactive\n    <?php\n      echo 'indented';\n    // Outputs: indented\n\t```",
 				"<?php\n  echo 'indented';",
 				'indented',
 			),
 			'three leading spaces are accepted' => array(
-				"   ```php interactive\n<?php echo 'three';\n```\n```expected-output\nthree\n   ```",
+				"   ```php interactive\n<?php echo 'three';\n// Outputs: three\n   ```",
 				"<?php echo 'three';",
 				'three',
 			),
@@ -740,19 +740,6 @@ class Export_Docblocks extends Export_UnitTestCase {
 	}
 
 	/**
-	 * Test that code-comment output cannot conflict with an expected-output fence.
-	 */
-	public function test_code_snippet_output_comment_and_fence_cannot_both_define_output() {
-
-		$this->expectException( \InvalidArgumentException::class );
-		$this->expectExceptionMessage( 'declares output both in code and in an expected-output fence' );
-
-		\WP_Parser\export_docblock_code_snippets(
-			"```php interactive\necho 'one';\n// Outputs (JSON-encoded): \"one\"\n```\n```expected-output\none\n```"
-		);
-	}
-
-	/**
 	 * Test that unsupported info strings remain ordinary documentation.
 	 *
 	 * @dataProvider unrecognized_code_fence_info_strings
@@ -782,6 +769,7 @@ class Export_Docblocks extends Export_UnitTestCase {
 			'collapsed Blueprint reference' => array( 'php interactive setupblueprint=shared', $php ),
 			'unsupported interactive option' => array( 'php interactive editable=false', $php ),
 			'output alias' => array( 'output', 'output' ),
+			'expected output fence' => array( 'expected-output', 'output' ),
 			'underscored expected output' => array( 'expected_output', 'output' ),
 			'typed expected output' => array( 'text/expected-output', 'output' ),
 			'uppercase PHP' => array( 'PHP interactive', $php ),
@@ -799,8 +787,8 @@ class Export_Docblocks extends Export_UnitTestCase {
 	/**
 	 * Test that each PHP fence is replaced with an inline placeholder, in order,
 	 * so the theme can render each snippet between the surrounding prose instead
-	 * of collapsing every snippet to the end of the description. Snippet-metadata
-	 * fences (expected-output, Blueprints) are removed.
+	 * of collapsing every snippet to the end of the description. Setup Blueprint
+	 * fences are removed.
 	 */
 	public function test_code_snippet_inline_placeholders() {
 
@@ -819,10 +807,7 @@ class Export_Docblocks extends Export_UnitTestCase {
 				'```php interactive',
 				'<?php',
 				'echo step_two();',
-				'```',
-				'',
-				'```expected-output',
-				'done',
+				'// Outputs: done',
 				'```',
 				'',
 				'Closing prose.',
@@ -841,7 +826,7 @@ class Export_Docblocks extends Export_UnitTestCase {
 		$this->assertGreaterThan( $first, strpos( $stripped, 'Middle prose.' ) );
 		$this->assertGreaterThan( $second, strpos( $stripped, 'Closing prose.' ) );
 
-		// No raw PHP fence or metadata fence is left behind in the description.
+		// No raw PHP fence is left behind in the description.
 		$this->assertStringNotContainsString( '```', $stripped );
 		$this->assertStringNotContainsString( '<?php', $stripped );
 
@@ -945,18 +930,12 @@ class Export_Docblocks extends Export_UnitTestCase {
 				'',
 				'    ```php interactive',
 				'    <?php echo 1;',
-				'    ```',
-				'',
-				'    ```expected-output',
-				'    1',
+				'    // Outputs: 1',
 				'    ```',
 				'',
 				'    ```php interactive',
 				'    <?php echo 2;',
-				'    ```',
-				'',
-				'    ```expected-output',
-				'    2',
+				'    // Outputs: 2',
 				'    ```',
 				'',
 				'After',
@@ -1013,9 +992,9 @@ class Export_Docblocks extends Export_UnitTestCase {
 	}
 
 	/**
-	 * Test that snippet metadata fences do not accept extra arguments.
+	 * Test that setup Blueprint fences do not accept extra arguments.
 	 */
-	public function test_code_snippet_metadata_rejects_extra_arguments() {
+	public function test_setup_blueprint_fence_rejects_extra_arguments() {
 
 		$this->assertEquals(
 			array(
@@ -1034,9 +1013,6 @@ class Export_Docblocks extends Export_UnitTestCase {
 						'```php interactive',
 						'<?php',
 						'echo docs_case_fixture();',
-						'```',
-						'```expected-output copied from a run',
-						'case fixture',
 						'```',
 					)
 				)
@@ -1300,57 +1276,7 @@ class Export_Docblocks extends Export_UnitTestCase {
 	}
 
 	/**
-	 * Test that metadata after expected output belongs to the next snippet.
-	 */
-	public function test_code_snippet_metadata_boundaries() {
-
-		$this->assertEquals(
-			array(
-				array(
-					'type' => 'php-code-snippet',
-					'code' => "<?php\necho 'First';",
-					'expected_output' => 'First',
-				),
-				array(
-					'type' => 'php-code-snippet',
-					'code' => "<?php\necho 'Second';",
-					'blueprint' => array(
-						'steps' => array(
-							array(
-								'step' => 'writeFile',
-								'path' => '/tmp/second.php',
-								'data' => '<?php echo "second setup";',
-							),
-						),
-					),
-				),
-			),
-			\WP_Parser\export_docblock_code_snippets(
-				implode(
-					"\n",
-					array(
-						'```php interactive',
-						'<?php',
-						'echo \'First\';',
-						'```',
-						'```expected-output',
-						'First',
-						'```',
-						'```setup-blueprint',
-						'{"steps":[{"step":"writeFile","path":"/tmp/second.php","data":"<?php echo \"second setup\";"}]}',
-						'```',
-						'```php interactive',
-						'<?php',
-						'echo \'Second\';',
-						'```',
-					)
-				)
-			)
-		);
-	}
-
-	/**
-	 * Test that recognized snippet metadata must belong to an interactive fence.
+	 * Test that inline setup Blueprints must belong to an interactive fence.
 	 *
 	 * @dataProvider unattached_snippet_metadata
 	 */
@@ -1367,11 +1293,8 @@ class Export_Docblocks extends Export_UnitTestCase {
 		$php = "```php interactive\n<?php echo 1;\n```";
 
 		return array(
-			'expected output before PHP' => array( "```expected-output\n1\n```\n" . $php ),
-			'expected output after prose' => array( $php . "\nProse.\n```expected-output\n1\n```" ),
 			'inline Blueprint before prose' => array( "```setup-blueprint\n{}\n```\nProse.\n" . $php ),
 			'inline Blueprint after prose' => array( $php . "\nProse.\n```setup-blueprint\n{}\n```" ),
-			'duplicate expected output' => array( $php . "\n```expected-output\n1\n```\n```expected-output\n2\n```" ),
 		);
 	}
 
@@ -1391,16 +1314,12 @@ class Export_Docblocks extends Export_UnitTestCase {
 					'```php interactive setup-blueprint=shared',
 					'<?php',
 					'echo "first";',
-					'```',
-					'```expected-output',
-					'first',
+					'// Outputs: first',
 					'```',
 					'```php interactive',
 					'<?php',
 					'echo "no leaked inline blueprint";',
-					'```',
-					'```expected-output',
-					'no leaked inline blueprint',
+					'// Outputs: no leaked inline blueprint',
 					'```',
 					'```php interactive setup-blueprint=shared',
 					'<?php',

--- a/tests/phpunit/tests/export/docblocks.php
+++ b/tests/phpunit/tests/export/docblocks.php
@@ -548,6 +548,27 @@ class Export_Docblocks extends Export_UnitTestCase {
 	}
 
 	/**
+	 * Test that text after Outputs is exported as a raw one-line value.
+	 */
+	public function test_inline_code_snippet_output_comment() {
+
+		$snippets = \WP_Parser\export_docblock_code_snippets(
+			"```php interactive\necho esc_html( '<egg>' );\n// Outputs: <egg>\n```"
+		);
+
+		$this->assertSame(
+			array(
+				array(
+					'type' => 'php-code-snippet',
+					'code' => "echo esc_html( '<egg>' );",
+					'expected_output' => '<egg>',
+				),
+			),
+			$snippets
+		);
+	}
+
+	/**
 	 * Test that a trailing Outputs comment block exports human-readable output.
 	 */
 	public function test_multiline_code_snippet_output_comment() {
@@ -661,15 +682,15 @@ class Export_Docblocks extends Export_UnitTestCase {
 	}
 
 	/**
-	 * Test that a trailing Outputs comment must use JSON-string syntax.
+	 * Test that a quoted Outputs comment must use valid JSON-string syntax.
 	 */
-	public function test_code_snippet_output_comment_requires_json_string() {
+	public function test_quoted_code_snippet_output_comment_requires_json_string() {
 
 		$this->expectException( \InvalidArgumentException::class );
-		$this->expectExceptionMessage( 'The trailing Outputs comment must contain one JSON string.' );
+		$this->expectExceptionMessage( 'The trailing quoted Outputs comment must contain one JSON string.' );
 
 		\WP_Parser\export_docblock_code_snippets(
-			"```php interactive\necho 'one';\n// Outputs: one\n```"
+			"```php interactive\necho 'one';\n// Outputs: \"one\n```"
 		);
 	}
 

--- a/tests/phpunit/tests/export/docblocks.php
+++ b/tests/phpunit/tests/export/docblocks.php
@@ -511,6 +511,69 @@ class Export_Docblocks extends Export_UnitTestCase {
 	}
 
 	/**
+	 * Test that a trailing Outputs comment becomes structured output metadata.
+	 */
+	public function test_code_snippet_output_comment() {
+
+		$snippets = \WP_Parser\export_docblock_code_snippets(
+			implode(
+				"\n",
+				array(
+					'```php interactive',
+					'$p = WP_HTML_Processor::create_fragment( "<div class=\'free &lt;egg&gt;\'\\tlang-en>" );',
+					'$p->next_tag();',
+					'foreach ( $p->class_list() as $class_name ) {',
+					'  echo "{$class_name} ";',
+					'}',
+					'// Outputs: "free <egg> lang-en "',
+					'```',
+				)
+			)
+		);
+
+		$this->assertSame(
+			array(
+				array(
+					'type' => 'php-code-snippet',
+					'code' => "\$p = WP_HTML_Processor::create_fragment( \"<div class='free &lt;egg&gt;'\\tlang-en>\" );\n" .
+						"\$p->next_tag();\n" .
+						"foreach ( \$p->class_list() as \$class_name ) {\n" .
+						"  echo \"{\$class_name} \";\n" .
+						'}',
+					'expected_output' => 'free <egg> lang-en ',
+				),
+			),
+			$snippets
+		);
+	}
+
+	/**
+	 * Test that a trailing Outputs comment must use JSON-string syntax.
+	 */
+	public function test_code_snippet_output_comment_requires_json_string() {
+
+		$this->expectException( \InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'The trailing Outputs comment must contain one JSON string.' );
+
+		\WP_Parser\export_docblock_code_snippets(
+			"```php interactive\necho 'one';\n// Outputs: one\n```"
+		);
+	}
+
+	/**
+	 * Test that code-comment output cannot conflict with an expected-output fence.
+	 */
+	public function test_code_snippet_output_comment_and_fence_cannot_both_define_output() {
+
+		$this->expectException( \InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'declares output both in code and in an expected-output fence' );
+
+		\WP_Parser\export_docblock_code_snippets(
+			"```php interactive\necho 'one';\n// Outputs: \"one\"\n```\n```expected-output\none\n```"
+		);
+	}
+
+	/**
 	 * Test that unsupported info strings remain ordinary documentation.
 	 *
 	 * @dataProvider unrecognized_code_fence_info_strings

--- a/tests/phpunit/tests/export/docblocks.php
+++ b/tests/phpunit/tests/export/docblocks.php
@@ -618,11 +618,11 @@ class Export_Docblocks extends Export_UnitTestCase {
 	}
 
 	/**
-	 * Test that older JSON-string Outputs comments retain their output value.
+	 * Test that quoted Outputs comments retain their output value.
 	 *
-	 * @dataProvider trailing_code_snippet_output_comments
+	 * @dataProvider quoted_code_snippet_output_comments
 	 */
-	public function test_trailing_code_snippet_output_comments( $comment, $expected_output ) {
+	public function test_quoted_code_snippet_output_comments( $comment, $expected_output ) {
 
 		$snippets = \WP_Parser\export_docblock_code_snippets(
 			"```php interactive\necho 'example';\n" . $comment . "\n```"
@@ -641,11 +641,15 @@ class Export_Docblocks extends Export_UnitTestCase {
 	}
 
 	/**
-	 * Returns JSON-string output comments with escaping that must survive export.
+	 * Returns quoted output comments with formatting that must survive export.
 	 */
-	public function trailing_code_snippet_output_comments() {
+	public function quoted_code_snippet_output_comments() {
 
 		return array(
+			'quoted output preserves trailing whitespace' => array(
+				'// Outputs: "ends with a space "',
+				'ends with a space ',
+			),
 			'multiline output with a trailing newline' => array(
 				'// Outputs: "first\\nsecond\\n"',
 				"first\nsecond\n",

--- a/tests/phpunit/tests/export/docblocks.php
+++ b/tests/phpunit/tests/export/docblocks.php
@@ -349,36 +349,31 @@ class Export_Docblocks extends Export_UnitTestCase {
 	 *
 	 * @dataProvider code_snippet_fence_delimiters
 	 */
-	public function test_code_snippet_fence_delimiters( $description, $expected_code, $expected_output ) {
+	public function test_code_snippet_fence_delimiters( $description, $expected_code ) {
 
 		$snippets = \WP_Parser\export_docblock_code_snippets( $description );
 
 		$this->assertCount( 1, $snippets );
 		$this->assertSame( $expected_code, $snippets[0]['code'] );
-		$this->assertSame( $expected_output, $snippets[0]['expected_output'] );
 	}
 
 	public function code_snippet_fence_delimiters() {
 		return array(
 			'smaller runs stay inside a larger fence' => array(
-				"````php interactive\n<?php\n```\necho 'inside';\n```\n// Outputs: outer\n````",
+				"````php interactive\n<?php\n```\necho 'inside';\n```\n````",
 				"<?php\n```\necho 'inside';\n```",
-				'outer',
 			),
 			'different runs and text do not close a fence' => array(
-				"```php interactive\n<?php\n````\necho 'inside';\n``` not a closer\necho 'still inside';\n// Outputs: exact\n```",
+				"```php interactive\n<?php\n````\necho 'inside';\n``` not a closer\necho 'still inside';\n```",
 				"<?php\n````\necho 'inside';\n``` not a closer\necho 'still inside';",
-				'exact',
 			),
 			'arbitrary indentation is removed from content' => array(
-				"    ```php interactive\n    <?php\n      echo 'indented';\n    // Outputs: indented\n\t```",
+				"    ```php interactive\n    <?php\n      echo 'indented';\n\t```",
 				"<?php\n  echo 'indented';",
-				'indented',
 			),
 			'three leading spaces are accepted' => array(
-				"   ```php interactive\n<?php echo 'three';\n// Outputs: three\n   ```",
+				"   ```php interactive\n<?php echo 'three';\n   ```",
 				"<?php echo 'three';",
-				'three',
 			),
 		);
 	}
@@ -710,6 +705,39 @@ class Export_Docblocks extends Export_UnitTestCase {
 				),
 			),
 			$snippets
+		);
+	}
+
+	/**
+	 * Test that Outputs text is metadata only in a trailing standalone line comment.
+	 *
+	 * @dataProvider php_code_containing_non_metadata_outputs_text
+	 */
+	public function test_php_code_containing_non_metadata_outputs_text( $code ) {
+
+		$this->assertSame(
+			array(
+				array(
+					'type' => 'php-code-snippet',
+					'code' => $code,
+				),
+			),
+			\WP_Parser\export_docblock_code_snippets( "```php interactive\n" . $code . "\n```" )
+		);
+	}
+
+	/**
+	 * Returns PHP tokens in which Outputs text is ordinary program text.
+	 */
+	public function php_code_containing_non_metadata_outputs_text() {
+
+		return array(
+			'string literal' => array( "echo '// Outputs: not metadata';" ),
+			'heredoc body' => array( "echo <<<TEXT\n// Outputs: not metadata\nTEXT;" ),
+			'block comment' => array( "echo 'done';\n/* // Outputs: not metadata */" ),
+			'comment after code on the same line' => array( "echo 'done'; // Outputs: not metadata" ),
+			'ordinary line comment' => array( '// Example containing // Outputs: not metadata' ),
+			'text after a PHP closing tag' => array( "<?php echo 'done'; ?>\n// Outputs: not PHP" ),
 		);
 	}
 

--- a/tests/phpunit/tests/export/docblocks.php
+++ b/tests/phpunit/tests/export/docblocks.php
@@ -618,6 +618,18 @@ class Export_Docblocks extends Export_UnitTestCase {
 	}
 
 	/**
+	 * Test that quoted output lines preserve trailing whitespace and newlines.
+	 */
+	public function test_multiline_code_snippet_output_comment_preserves_trailing_whitespace() {
+
+		$snippets = \WP_Parser\export_docblock_code_snippets(
+			"```php interactive\necho 'done';\n// Outputs:\n// first\n// \"second \"\n//\n//\n```"
+		);
+
+		$this->assertSame( "first\nsecond \n\n", $snippets[0]['expected_output'] );
+	}
+
+	/**
 	 * Test that quoted Outputs comments retain their output value.
 	 *
 	 * @dataProvider quoted_code_snippet_output_comments
@@ -691,7 +703,7 @@ class Export_Docblocks extends Export_UnitTestCase {
 	public function test_quoted_code_snippet_output_comment_requires_json_string() {
 
 		$this->expectException( \InvalidArgumentException::class );
-		$this->expectExceptionMessage( 'The trailing quoted Outputs comment must contain one JSON string.' );
+		$this->expectExceptionMessage( 'A quoted Outputs comment must contain one JSON string.' );
 
 		\WP_Parser\export_docblock_code_snippets(
 			"```php interactive\necho 'one';\n// Outputs: \"one\n```"

--- a/tests/phpunit/tests/export/docblocks.php
+++ b/tests/phpunit/tests/export/docblocks.php
@@ -548,7 +548,56 @@ class Export_Docblocks extends Export_UnitTestCase {
 	}
 
 	/**
-	 * Test that JSON escapes in a trailing Outputs comment retain their output value.
+	 * Test that a trailing Outputs comment block exports human-readable output.
+	 */
+	public function test_multiline_code_snippet_output_comment() {
+
+		$snippets = \WP_Parser\export_docblock_code_snippets(
+			implode(
+				"\n",
+				array(
+					'```php interactive',
+					'$values = array(',
+					"\t'fruit' => 'apple',",
+					');',
+					'print_r( $values );',
+					'// Outputs:',
+					'// Array',
+					'// (',
+					'//     [fruit] => apple',
+					'// )',
+					'//',
+					'```',
+				)
+			)
+		);
+
+		$this->assertSame(
+			array(
+				array(
+					'type' => 'php-code-snippet',
+					'code' => "\$values = array(\n\t'fruit' => 'apple',\n);\nprint_r( \$values );",
+					'expected_output' => "Array\n(\n    [fruit] => apple\n)\n",
+				),
+			),
+			$snippets
+		);
+	}
+
+	/**
+	 * Test that a human-readable output block preserves literal Unicode text.
+	 */
+	public function test_multiline_code_snippet_output_comment_preserves_unicode() {
+
+		$snippets = \WP_Parser\export_docblock_code_snippets(
+			"```php interactive\necho 'done';\n// Outputs:\n// ✅ Complete\n```"
+		);
+
+		$this->assertSame( '✅ Complete', $snippets[0]['expected_output'] );
+	}
+
+	/**
+	 * Test that older JSON-string Outputs comments retain their output value.
 	 *
 	 * @dataProvider trailing_code_snippet_output_comments
 	 */

--- a/tests/phpunit/tests/export/fence-first-docblocks.inc
+++ b/tests/phpunit/tests/export/fence-first-docblocks.inc
@@ -48,10 +48,7 @@ function fence_first_period_example() {
  *   @author( 'indentation makes this part of the preceding tag' );
  * @since( 'inside-fence' );
  * echo 'at sign';
- * ```
- *
- * ```expected-output
- * at sign
+ * // Outputs: at sign
  * ```
  *
  * @since 1.0.0


### PR DESCRIPTION
Core PR WordPress/wordpress-develop#13267 replaces a separate `expected-output` fence with a trailing output comment.

This PR adds support for the `// Outputs: ` syntax to the runnable code snippets. That is in addition to the already supported `expected-output` syntax. 

## Output formats

### Literal one-line output

```php
echo esc_html( "<egg>" );
// Outputs: <egg>
```

Everything after `// Outputs:` is literal output. Quotes and other punctuation have no special meaning.

```json
{
  "code": "echo esc_html( \"<egg>\" );",
  "expected_output": "<egg>"
}
```

### Literal multiline output

```php
print_r( array( "fruit" => "apple" ) );
// Outputs:
// Array
// (
//     [fruit] => apple
// )
//
```

An empty `// Outputs:` starts a multiline block. Each following `//` is one output line. One space after `//` is the comment delimiter; further indentation is output.

Empty final comments preserve final newlines. Quotes remain literal:

```php
// Outputs:
// first
// "second "
//
```

This exports `"first\n\"second \"\n"`.

### JSON-encoded output

```php
echo "done ";
// Outputs (JSON-encoded): "done "
```

`// Outputs (JSON-encoded):` requires one JSON string. Use it when otherwise invisible trailing whitespace, tabs, escaped quotes, or several encoded newlines must be explicit:

```php
// Outputs (JSON-encoded): "first\nsecond \n\n"
```

The format is selected by the header, never by the output text. Unicode can remain literal in the DocBlock, including `// Outputs (JSON-encoded): "✅ Complete "`.

The `expected-output` fence remains supported for compatibility. It is still attached to the preceding interactive PHP fence and removed from rendered documentation. New examples should use one of the trailing comment forms above. The exported JSON shape stays the same, so consumers continue to receive `expected_output` as a string.

## Testing

The expanded unit tests cover literal one-line and multiline output, literal quotes, indentation, trailing spaces, one and several final newlines, Unicode, valid JSON escapes, malformed JSON, non-string JSON values, non-final comments, strings, heredocs, block comments, same-line comments, text after a PHP closing tag, expected-output fence compatibility, output conflicts, and unattached metadata errors.
